### PR TITLE
fix(build): make dev watch mode write dist/index.html for Figma

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```sh
 npm install                    # install deps (also run: npm install --save-dev @figma/plugin-typings)
-npm run start                  # dev mode: runs tsc:watch + build:main:watch + vite concurrently (aliased by npm run dev)
+npm run start                  # dev mode: runs tsc:watch + build:main:watch + build:ui:watch concurrently (aliased by npm run dev)
 npm run build                  # tsc -b && vite build --emptyOutDir=false && npm run build:main
 npm run build:main             # esbuild-bundle plugin/code.ts -> dist/code.js (sandbox bundle only)
+npm run build:ui:watch         # vite build --watch --emptyOutDir=false -> dist/index.html (UI bundle, watch mode)
 npm run lint                   # eslint src/**/*.{js,jsx,ts,tsx}, --max-warnings=0
 npm run lint:fix               # eslint --fix, same scope
 npm run preview                # vite preview
@@ -25,7 +26,7 @@ Commits are enforced via Husky + commitlint (`config/commitlint.config.mjs`, ext
 This is a Figma plugin, which means the build produces **two separate JS runtimes that only talk via `postMessage`** — this split drives most of the structure:
 
 - **Plugin sandbox** (`plugin/code.ts` → bundled by esbuild to `dist/code.js`): runs in Figma's plugin sandbox. Has access to the `figma` global API (scene graph, node mutation, `figma.notify`, etc.) but no DOM and no `fetch`. Note it starts with `// @ts-nocheck` — this file is intentionally excluded from type checking.
-- **UI iframe** (`src/`, React + Vite → `dist/index.html`): a normal DOM environment (has `fetch`, `window`, `document`) but no access to the `figma` API. Built with `vite-plugin-singlefile` because Figma plugin UI must ship as one self-contained HTML file — check `vite.config.ts`'s `assetsInlineLimit`/`cssCodeSplit` settings before adding new asset-loading patterns.
+- **UI iframe** (`src/`, React + Vite → `dist/index.html`): a normal DOM environment (has `fetch`, `window`, `document`) but no access to the `figma` API. Built with `vite-plugin-singlefile` because Figma plugin UI must ship as one self-contained HTML file — check `vite.config.ts`'s `assetsInlineLimit`/`cssCodeSplit` settings before adding new asset-loading patterns. Figma reads `dist/index.html` straight off disk, so the UI must always be built via `vite build` (what `build:ui:watch` runs in watch mode) — the plain `vite` dev server serves from memory over HTTP and never writes `dist/index.html`, so it won't reflect in Figma.
 
 Communication between the two is one-directional message-passing, wrapped in helpers in `src/lib/figmaUtils.ts`:
 

--- a/package.json
+++ b/package.json
@@ -15,12 +15,13 @@
     "build": "tsc -b && vite build --emptyOutDir=false && npm run build:main",
     "build:main": "esbuild plugin/code.ts --bundle --outfile=dist/code.js",
     "build:main:watch": "esbuild plugin/code.ts --bundle --outfile=dist/code.js --watch",
+    "build:ui:watch": "vite build --watch --emptyOutDir=false",
     "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --max-warnings=0 --no-warn-ignored",
     "lint:debug": "eslint --ext .jsx,.js,.ts,.tsx ./src --debug --max-warnings=0",
     "lint:fix": "npx eslint \"src/**/*.{js,jsx,ts,tsx}\" --fix --max-warnings=0 --no-warn-ignored",
     "prepare": "husky",
     "preview": "vite preview",
-    "start": "concurrently -n tsc,build,vite -c yellow,blue,green \"npm run tsc:watch\" \"npm run build:main:watch\" \"vite\"",
+    "start": "concurrently -n tsc,build,ui -c yellow,blue,green \"npm run tsc:watch\" \"npm run build:main:watch\" \"npm run build:ui:watch\"",
     "tsc:watch": "tsc -b --watch --preserveWatchOutput"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- `npm run start` ran bare `vite`, which starts Vite's in-memory dev server (HTTP + HMR) and never writes `dist/index.html` to disk
- Figma loads the plugin UI straight from `dist/index.html`, so UI changes never actually showed up while iterating in Figma's dev mode under watch mode — only a full `npm run build` refreshed it
- Added `build:ui:watch` (`vite build --watch --emptyOutDir=false`), which reruns the real production build (including `vite-plugin-singlefile` inlining) on every save and writes the file Figma actually reads
- `start`/`dev` now runs `tsc:watch` + `build:main:watch` + `build:ui:watch` concurrently
- Updated `CLAUDE.md` to document the new script and why the bare `vite` dev server doesn't work for this project

## Test plan
- [x] `npm run build:ui:watch`, confirmed `dist/index.html` is written on startup
- [x] `npm run build` (one-shot) still produces `dist/code.js` + `dist/index.html`
- [ ] Manually run `npm run start`, edit a UI component, confirm `dist/index.html` updates without re-running `npm run build`, and reload the plugin in Figma dev mode to see the change