### PR TITLE
fix(ui): guard against missing data/error fields in alt-text failure response

### DIFF
--- a/src/components/organisms/ai-assistants/AltTextGenerator.tsx
+++ b/src/components/organisms/ai-assistants/AltTextGenerator.tsx
@@ -45,12 +45,12 @@ export default function AltTextGenerator({
           );
 
           if (!response.ok) {
-            const result = await response.json();
+            const result = await response.json().catch(() => null);
 
-            if (result.data.remaining === 0) {
+            if (result?.data?.remaining === 0) {
               setRemainingQuotaValue(result.data.remaining);
             }
-            setIsQuotaExceeded(result.error);
+            setIsQuotaExceeded(result?.error ?? null);
             throw new Error(`HTTP error! status: ${response.status}`);
           }
 
@@ -81,7 +81,8 @@ export default function AltTextGenerator({
               altTextArea.current.textContent =
                 "Network error. Please try again.";
             } else {
-              altTextArea.current.textContent = "";
+              altTextArea.current.textContent =
+                "Something went wrong generating alt text. Please try again.";
             }
           }
         }


### PR DESCRIPTION
## Summary
Reported symptom: alt-text generation fails with a 500 from the Cloudflare Worker (`zimmar-d1.praizjosh.workers.dev/generate-alt-text`), and the console additionally shows `TypeError: Cannot read properties of undefined (reading 'remaining')`.

The 500 itself is server-side (that worker isn't in this repo, so its root cause needs investigating separately — likely a quota/provider issue on the worker). This PR fixes a real client-side bug that was masking it:

- `AltTextGenerator.tsx`'s `!response.ok` branch assumed the error response always had a `{ data: { remaining }, error }` shape and read `result.data.remaining` unguarded
- When the worker returns a 500 without that shape (or a non-JSON body), that line throws, which gets caught by the outer `catch` and silently clears the alt-text area with an empty string — no indication anything went wrong
- Guarded the lookups with optional chaining and a `.catch(() => null)` on the JSON parse, and gave the default catch-all branch an actual user-facing message instead of `""`

## Test plan
- [x] `npm run lint` passes
- [x] `npx tsc -b` passes
- [x] `npm run build` passes
- [ ] Manually verify in Figma: trigger a failed alt-text request (e.g. while the worker is erroring) and confirm a message shows instead of a blank text area
- [ ] Separately: investigate the 500 on the worker side (outside this repo) to fix the underlying failure