### PR TITLE
fix(contrast): read the topmost visible fill for foreground color

### DIFF
--- a/src/components/organisms/IssuesWrapper.tsx
+++ b/src/components/organisms/IssuesWrapper.tsx
@@ -37,6 +37,7 @@ export default function IssuesWrapper({
   const [isQuickCheckActive, setIsQuickCheckActive] = useState(false);
   const [isSelection, setIsSelection] = useState(true);
   const [hasBackground, setHasBackground] = useState("");
+  const [hasForeground, setHasForeground] = useState("");
   const {
     currentIndex,
     singleIssue,
@@ -79,6 +80,10 @@ export default function IssuesWrapper({
 
     if (type === "no-background") {
       setHasBackground(data);
+    }
+
+    if (type === "no-foreground") {
+      setHasForeground(data);
     }
   };
 
@@ -138,6 +143,10 @@ export default function IssuesWrapper({
 
           {isSelection && hasBackground && selectedType === "Contrast" && (
             <p className="text-sm">{hasBackground}</p>
+          )}
+
+          {isSelection && hasForeground && selectedType === "Contrast" && (
+            <p className="text-sm">{hasForeground}</p>
           )}
         </div>
       );

--- a/src/lib/figmaUtils.test.ts
+++ b/src/lib/figmaUtils.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { extractForegroundColor } from "./figmaUtils";
+
+function solidFill(
+  r: number,
+  g: number,
+  b: number,
+  visible: boolean = true,
+): Paint {
+  return { type: "SOLID", visible, color: { r, g, b } } as Paint;
+}
+
+describe("extractForegroundColor", () => {
+  it("returns the color of a single visible solid fill", () => {
+    const fills = [solidFill(1, 0, 0)];
+
+    expect(extractForegroundColor(fills)).toEqual([255, 0, 0]);
+  });
+
+  it("returns the topmost (last) visible solid fill, not the first", () => {
+    const fills = [solidFill(1, 0, 0), solidFill(0, 0, 1)];
+
+    expect(extractForegroundColor(fills)).toEqual([0, 0, 255]);
+  });
+
+  it("skips an invisible fill on top and falls back to the visible solid beneath it", () => {
+    const fills = [solidFill(1, 0, 0), solidFill(0, 0, 1, false)];
+
+    expect(extractForegroundColor(fills)).toEqual([255, 0, 0]);
+  });
+
+  it("skips non-solid fills (e.g. gradients) when scanning for the topmost solid", () => {
+    const gradient = { type: "GRADIENT_LINEAR", visible: true } as Paint;
+    const fills = [solidFill(0, 1, 0), gradient];
+
+    expect(extractForegroundColor(fills)).toEqual([0, 255, 0]);
+  });
+
+  it("returns null when there are no fills", () => {
+    expect(extractForegroundColor([])).toBeNull();
+  });
+
+  it("returns null when no fill is a visible solid", () => {
+    const gradient = { type: "GRADIENT_LINEAR", visible: true } as Paint;
+    const invisibleSolid = solidFill(1, 1, 1, false);
+
+    expect(extractForegroundColor([gradient, invisibleSolid])).toBeNull();
+  });
+});

--- a/src/lib/figmaUtils.ts
+++ b/src/lib/figmaUtils.ts
@@ -38,18 +38,22 @@ export function postMessageToBackend(
 /**
  * Extracts the foreground color from the given Paint array.
  *
+ * Figma's fills array is ordered back-to-front — the last entry is
+ * rendered on top of the others — so this scans from the end to find
+ * the topmost visible SOLID fill, which is what's actually rendered.
+ *
  * @param {Paint[]} nodeFills - Array of Paint objects from a Figma node.
- * @returns {RGBColor} An RGB array representing the foreground color.
+ * @returns {RGBColor | null} The rendered foreground color, or null if
+ * no visible solid fill exists (e.g. gradient/image-only fills).
  */
-export const extractForegroundColor = (nodeFills: Paint[]): RGBColor => {
-  if (
-    nodeFills.length > 0 &&
-    nodeFills[0].type === "SOLID" &&
-    nodeFills[0].visible !== false
-  ) {
-    return figmaRGBtoRGBColor(nodeFills[0].color);
+export const extractForegroundColor = (nodeFills: Paint[]): RGBColor | null => {
+  for (let i = nodeFills.length - 1; i >= 0; i--) {
+    const fill = nodeFills[i];
+    if (fill.type === "SOLID" && fill.visible !== false) {
+      return figmaRGBtoRGBColor(fill.color);
+    }
   }
-  return [0, 0, 0]; // Default black
+  return null;
 };
 
 /**
@@ -262,6 +266,14 @@ export async function analyzeTextNodeForContrastIssue(
 
     // Skip nodes with mixed font sizes
     if (fontSize === figma.mixed) return;
+
+    if (!foregroundColor) {
+      postMessageToUI(
+        "no-foreground",
+        `No solid foreground color detected for the selected layer. Please check the layer's properties.`,
+      );
+      return;
+    }
 
     if (!backgroundColor) {
       postMessageToUI(


### PR DESCRIPTION
extractForegroundColor only ever checked fills[0] and silently defaulted to black when it wasn't a visible solid. Figma's fills array is ordered back-to-front, so for a text node with multiple fills this read the wrong (bottom) paint instead of what's actually rendered on top, and the black fallback could produce misleading contrast results for gradient/image-fill or fully-invisible-fill text nodes.

Scan the fills array in reverse to find the topmost visible SOLID fill, and return null instead of fabricating black when none exists. analyzeTextNodeForContrastIssue now bails out with a "no-foreground" message when that happens, mirroring the existing "no-background" handling, and IssuesWrapper.tsx surfaces it the same way.

Adds a vitest suite for extractForegroundColor covering single-fill, topmost-fill-wins, invisible/non-solid fills, and both null cases. Verified these tests catch the original bug (3/6 fail against the old fills[0]-only implementation).