### PR TITLE
refactor: centralize plugin<->UI message type strings in MESSAGE_TYPES

### DIFF
--- a/plugin/code.ts
+++ b/plugin/code.ts
@@ -72,18 +72,18 @@ figma.on("selectionchange", async () => {
   const selection = figma.currentPage.selection;
 
   if (selection.length === 0) {
-    postMessageToUI("no-selection", true);
+    postMessageToUI(MESSAGE_TYPES.NO_SELECTION, true);
     return;
   }
 
   if (selection.length > 0) {
-    postMessageToUI("layer-selected", true);
+    postMessageToUI(MESSAGE_TYPES.LAYER_SELECTED, true);
   }
 
   try {
     const detectedIssues = await detectIssuesInSelection(selection);
     if (detectedIssues.length) {
-      postMessageToUI("detected-issue", detectedIssues);
+      postMessageToUI(MESSAGE_TYPES.DETECTED_ISSUE, detectedIssues);
     }
   } catch (error) {
     console.error("Error in selectionchange handler:", error);
@@ -93,19 +93,19 @@ figma.on("selectionchange", async () => {
 async function handleStartQuickCheck() {
   setIsQuickCheckModeActive(true);
 
-  postMessageToUI("quickcheck-active", getIsQuickCheckModeActive());
+  postMessageToUI(MESSAGE_TYPES.QUICKCHECK_ACTIVE, getIsQuickCheckModeActive());
 
   const selection = figma.currentPage.selection;
 
   if (selection.length === 0) {
-    postMessageToUI("no-selection", true);
+    postMessageToUI(MESSAGE_TYPES.NO_SELECTION, true);
     return;
   }
 
   try {
     const detectedIssues = await detectIssuesInSelection(selection);
     if (detectedIssues.length) {
-      postMessageToUI("detected-issue", detectedIssues);
+      postMessageToUI(MESSAGE_TYPES.DETECTED_ISSUE, detectedIssues);
     }
   } catch (error) {
     console.error("Error in selectionchange handler:", error);
@@ -132,7 +132,7 @@ async function handleScan() {
   ) as SceneNode[];
 
   const issues: IssueX[] = await collectIssues(allTextNodes, allPageNodes);
-  postMessageToUI("loadIssues", issues);
+  postMessageToUI(MESSAGE_TYPES.LOAD_ISSUES, issues);
 }
 
 async function handleUpdateFontSize(message: { id: string; fontSize: number }) {

--- a/src/components/organisms/AccessibilityValidator.tsx
+++ b/src/components/organisms/AccessibilityValidator.tsx
@@ -1,6 +1,7 @@
 import AltTextGenerator from "@/components/organisms/ai-assistants/AltTextGenerator";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { MESSAGE_TYPES } from "@/lib/constants";
 import { postMessageToBackend } from "@/lib/figmaUtils";
 import { ISSUES_DATA_SCHEMA } from "@/lib/issuesData";
 import { IssueType } from "@/lib/types";
@@ -13,7 +14,7 @@ export default function AccessibilityValidator() {
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
   const handleIssuesListClick = (type: IssueType) => {
-    postMessageToBackend("start-quickcheck");
+    postMessageToBackend(MESSAGE_TYPES.START_QUICKCHECK);
     setSelectedType(type);
     navigateTo(
       type === "Touch Target Size" || type === "Touch Target Spacing"

--- a/src/components/organisms/IssuesNavigator.tsx
+++ b/src/components/organisms/IssuesNavigator.tsx
@@ -1,7 +1,7 @@
 import IssueDetailRow from "@/components/organisms/IssueDetailRow";
 import IssuesWrapper from "@/components/organisms/IssuesWrapper";
 import Input from "@/components/ui/input";
-import { MIN_FONT_SIZE } from "@/lib/constants";
+import { MESSAGE_TYPES, MIN_FONT_SIZE } from "@/lib/constants";
 import { postMessageToBackend } from "@/lib/figmaUtils";
 import { IssueX } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
@@ -41,7 +41,7 @@ export default function IssuesNavigator() {
         });
       }
 
-      postMessageToBackend("updateFontSize", payload);
+      postMessageToBackend(MESSAGE_TYPES.UPDATE_FONT_SIZE, payload);
     }
   };
 

--- a/src/components/organisms/IssuesOverviewList.tsx
+++ b/src/components/organisms/IssuesOverviewList.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { ISSUES_TYPES } from "@/lib/constants";
+import { ISSUES_TYPES, MESSAGE_TYPES } from "@/lib/constants";
 import { ISSUES_DATA_SCHEMA } from "@/lib/issuesData";
 import { IssueType, IssueX } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
@@ -42,7 +42,7 @@ export default function IssuesOverviewList() {
 
     const { type, data } = event.data.pluginMessage;
 
-    if (type === "loadIssues") {
+    if (type === MESSAGE_TYPES.LOAD_ISSUES) {
       setIssues(data);
       setScanning(false);
     }

--- a/src/components/organisms/IssuesWrapper.tsx
+++ b/src/components/organisms/IssuesWrapper.tsx
@@ -2,6 +2,7 @@ import Recommendations from "@/components/organisms/Recommendations";
 import TooltipInfo from "@/components/organisms/TooltipInfo";
 import { Button } from "@/components/ui/button";
 import Separator from "@/components/ui/separator";
+import { MESSAGE_TYPES } from "@/lib/constants";
 import { postMessageToBackend } from "@/lib/figmaUtils";
 import { ISSUE_RECOMMENDATIONS } from "@/lib/issuesData";
 import { IssueType, IssueX } from "@/lib/types";
@@ -51,7 +52,7 @@ export default function IssuesWrapper({
   onmessage = (event: MessageEvent) => {
     const { type, data } = event.data.pluginMessage || {};
 
-    if (type === "detected-issue") {
+    if (type === MESSAGE_TYPES.DETECTED_ISSUE) {
       const matchingIssues = data.filter(
         (issue: IssueX) =>
           issue.type?.toLowerCase() === selectedType.toLowerCase(),
@@ -65,24 +66,24 @@ export default function IssuesWrapper({
       setSingleIssue(matchingIssues[0] || data[0] || null);
     }
 
-    if (type === "layer-selected" && data) {
+    if (type === MESSAGE_TYPES.LAYER_SELECTED && data) {
       setIsSelection(true);
     }
 
-    if (type === "no-selection" && data) {
+    if (type === MESSAGE_TYPES.NO_SELECTION && data) {
       setSingleIssue(null);
       setIsSelection(false);
     }
 
-    if (type === "quickcheck-active") {
+    if (type === MESSAGE_TYPES.QUICKCHECK_ACTIVE) {
       setIsQuickCheckActive(data);
     }
 
-    if (type === "no-background") {
+    if (type === MESSAGE_TYPES.NO_BACKGROUND) {
       setHasBackground(data);
     }
 
-    if (type === "no-foreground") {
+    if (type === MESSAGE_TYPES.NO_FOREGROUND) {
       setHasForeground(data);
     }
   };
@@ -95,7 +96,7 @@ export default function IssuesWrapper({
     if (isQuickCheckActive) {
       navigateTo("INDEX");
       setSingleIssue(null);
-      postMessageToBackend("cancel-quickcheck");
+      postMessageToBackend(MESSAGE_TYPES.CANCEL_QUICKCHECK);
     } else {
       navigateTo("ISSUE_OVERVIEW_LIST_VIEW");
     }

--- a/src/components/organisms/ai-assistants/AltTextGenerator.tsx
+++ b/src/components/organisms/ai-assistants/AltTextGenerator.tsx
@@ -28,7 +28,7 @@ export default function AltTextGenerator({
     const handleMessage = async (event: MessageEvent) => {
       const { type, data } = event.data.pluginMessage || {};
 
-      if (type === "GENERATE_ALT_TEXT") {
+      if (type === MESSAGE_TYPES.GENERATE_ALT_TEXT) {
         try {
           if (altTextArea.current) {
             altTextArea.current.textContent = "Generating alt text...";
@@ -99,7 +99,7 @@ export default function AltTextGenerator({
   }, []);
 
   function generateAltText() {
-    parent.postMessage({ pluginMessage: { type: "get-image-data" } }, "*");
+    postMessageToBackend(MESSAGE_TYPES.GET_IMAGE_DATA);
   }
 
   function handleCopyClick() {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,11 +2,18 @@ export const MESSAGE_TYPES = {
   START_QUICKCHECK: "start-quickcheck",
   CANCEL_QUICKCHECK: "cancel-quickcheck",
   SCAN: "scan",
-  UPDATE_FONT_SIZE: "updateFontSize",
+  UPDATE_FONT_SIZE: "update-font-size",
   NAVIGATE: "navigate",
   GET_IMAGE_DATA: "get-image-data",
-  GENERATE_ALT_TEXT: "GENERATE_ALT_TEXT",
+  GENERATE_ALT_TEXT: "generate-alt-text",
   NOTIFY: "notify",
+  DETECTED_ISSUE: "detected-issue",
+  LAYER_SELECTED: "layer-selected",
+  NO_SELECTION: "no-selection",
+  QUICKCHECK_ACTIVE: "quickcheck-active",
+  NO_BACKGROUND: "no-background",
+  NO_FOREGROUND: "no-foreground",
+  LOAD_ISSUES: "load-issues",
 };
 
 export const ISSUES_TYPES = [

--- a/src/lib/figmaUtils.ts
+++ b/src/lib/figmaUtils.ts
@@ -1,6 +1,7 @@
 import { contrastScore, IssueX } from "@/lib/types";
 import { RGBColor } from "wcag-contrast";
 import {
+  MESSAGE_TYPES,
   MIN_TOUCH_TARGET_SIZE,
   MIN_TOUCH_TARGET_SPACING,
   TOUCH_TARGET_KEYWORDS,
@@ -269,7 +270,7 @@ export async function analyzeTextNodeForContrastIssue(
 
     if (!foregroundColor) {
       postMessageToUI(
-        "no-foreground",
+        MESSAGE_TYPES.NO_FOREGROUND,
         `No solid foreground color detected for the selected layer. Please check the layer's properties.`,
       );
       return;
@@ -277,7 +278,7 @@ export async function analyzeTextNodeForContrastIssue(
 
     if (!backgroundColor) {
       postMessageToUI(
-        "no-background",
+        MESSAGE_TYPES.NO_BACKGROUND,
         `No background elements detected for the selected layer. Please check the layer's properties.`,
       );
       return;

--- a/src/lib/helpers/generateAltTextForLayer.ts
+++ b/src/lib/helpers/generateAltTextForLayer.ts
@@ -1,3 +1,5 @@
+import { MESSAGE_TYPES } from "../constants";
+import { postMessageToUI } from "../figmaUtils";
 import getUniqueUserId from "./getUniqueUserId";
 
 /**
@@ -98,10 +100,7 @@ export default async function generateAltTextForLayer() {
       feature: "generate-alt-text",
     };
 
-    figma.ui.postMessage({
-      type: "GENERATE_ALT_TEXT",
-      data: requestData,
-    });
+    postMessageToUI(MESSAGE_TYPES.GENERATE_ALT_TEXT, requestData);
   } catch (error) {
     console.error("Error generating alt text:", error);
   }

--- a/src/lib/useIssuesStore.ts
+++ b/src/lib/useIssuesStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { MESSAGE_TYPES } from "./constants";
 import { postMessageToBackend } from "./figmaUtils";
 import { EnhancedIssuesStore, IssueType, IssueX, Routes } from "./types";
 
@@ -16,7 +17,7 @@ const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
   startScan: () => {
     const { setScanning, navigateTo } = get();
     setScanning(true);
-    postMessageToBackend("scan");
+    postMessageToBackend(MESSAGE_TYPES.SCAN);
     navigateTo("ISSUE_OVERVIEW_LIST_VIEW");
   },
   setSingleIssue: (newIssue) => set({ singleIssue: newIssue }),


### PR DESCRIPTION
## Summary
Stacked on #17 — message type strings for both directions of the plugin/UI `postMessage` bridge were scattered as raw string literals with no single source of truth. This routes every send/receive site through `MESSAGE_TYPES` (`src/lib/constants.ts`) instead:

- Extended `MESSAGE_TYPES` with the sandbox→UI message types that weren't previously centralized (`detected-issue`, `layer-selected`, `no-selection`, `quickcheck-active`, `no-background`, `no-foreground`, `load-issues`)
- Updated every `postMessageToUI`/`postMessageToBackend` call and every `type === "..."` check across `plugin/code.ts`, `figmaUtils.ts`, `generateAltTextForLayer.ts`, and the UI components that listen for these messages
- Normalized `MESSAGE_TYPES` values to be consistently kebab-case (`updateFontSize` → `update-font-size`, `GENERATE_ALT_TEXT` → `generate-alt-text`, `loadIssues` → `load-issues`) — safe now that nothing references the raw strings directly
- Fixed two spots that bypassed the shared helpers entirely: `AltTextGenerator.tsx`'s `generateAltText()` now calls `postMessageToBackend` instead of a raw `parent.postMessage`, and `generateAltTextForLayer.ts` now calls `postMessageToUI` instead of a raw `figma.ui.postMessage`
- `IssuesWrapperOriginal.tsx` left untouched — confirmed unused dead code via import trace, already flagged for deletion as a separate roadmap item

## Test plan
- [x] `npm run lint` passes
- [x] `npx tsc -b` passes
- [x] `npm run test` passes (10/10)
- [x] `npm run build` passes
- [ ] Manually verify in Figma: full scan, quick check (including no-selection/no-background/no-foreground states), font-size update, alt-text generation all still work end to end