### PR TITLE
chore: split husky hooks into conventional pre-commit/commit-msg

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx lint-staged && npx --no -- commitlint --edit $1 --config config/commitlint.config.mjs
+npx --no -- commitlint --edit $1 --config config/commitlint.config.mjs

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged


### PR DESCRIPTION
## Summary
- `.husky/commit-msg` was running both `lint-staged` and `commitlint` together, with no `.husky/pre-commit` at all
- Split into the conventional layout: `pre-commit` runs `lint-staged`, `commit-msg` only runs `commitlint`

## Test plan
- [x] Verified both hooks fire correctly by running them directly:
  - `sh .husky/_/pre-commit` → runs lint-staged successfully
  - `sh .husky/_/commit-msg` with a valid Conventional Commit message → passes
  - `sh .husky/_/commit-msg` with an invalid message ("did some stuff") → correctly rejected with commitlint errors