### PR TITLE
refactor: use MESSAGE_TYPES.NAVIGATE in useIssuesStore.navigateToIssue

### DIFF
--- a/src/lib/useIssuesStore.ts
+++ b/src/lib/useIssuesStore.ts
@@ -59,15 +59,9 @@ const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
     const issueGroupList = getIssueGroupList();
 
     if (index >= 0 && index < issueGroupList.length) {
-      parent.postMessage(
-        {
-          pluginMessage: {
-            type: "navigate",
-            id: issueGroupList[index].nodeData.id,
-          },
-        },
-        "*",
-      );
+      postMessageToBackend(MESSAGE_TYPES.NAVIGATE, {
+        id: issueGroupList[index].nodeData.id,
+      });
       set({ currentIndex: index });
     }
   },

--- a/src/lib/useIssuesStore/index.test.ts
+++ b/src/lib/useIssuesStore/index.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IssueX } from "../types";
+
+const { postMessageToBackend } = vi.hoisted(() => ({
+  postMessageToBackend: vi.fn(),
+}));
+
+vi.mock("../figmaUtils", () => ({ postMessageToBackend }));
+
+import { MESSAGE_TYPES } from "../constants";
+import useIssuesStore from "./index";
+
+const issues: IssueX[] = [
+  {
+    type: "Typography",
+    severity: "major",
+    nodeData: { id: "node-1", name: "Label A", nodeType: "TEXT" },
+  },
+  {
+    type: "Typography",
+    severity: "major",
+    nodeData: { id: "node-2", name: "Label B", nodeType: "TEXT" },
+  },
+];
+
+describe("useIssuesStore.navigateToIssue", () => {
+  beforeEach(() => {
+    postMessageToBackend.mockClear();
+    useIssuesStore.setState({
+      issues,
+      selectedType: "Typography",
+      currentIndex: 0,
+    });
+  });
+
+  it("posts MESSAGE_TYPES.NAVIGATE with the target node's id and updates currentIndex", () => {
+    useIssuesStore.getState().navigateToIssue(1);
+
+    expect(postMessageToBackend).toHaveBeenCalledWith(MESSAGE_TYPES.NAVIGATE, {
+      id: "node-2",
+    });
+    expect(useIssuesStore.getState().currentIndex).toBe(1);
+  });
+
+  it("does nothing when the index is out of range", () => {
+    useIssuesStore.getState().navigateToIssue(5);
+
+    expect(postMessageToBackend).not.toHaveBeenCalled();
+    expect(useIssuesStore.getState().currentIndex).toBe(0);
+  });
+
+  it("does nothing when the index is negative", () => {
+    useIssuesStore.getState().navigateToIssue(-1);
+
+    expect(postMessageToBackend).not.toHaveBeenCalled();
+    expect(useIssuesStore.getState().currentIndex).toBe(0);
+  });
+});

--- a/src/lib/useIssuesStore/index.ts
+++ b/src/lib/useIssuesStore/index.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
-import { MESSAGE_TYPES } from "./constants";
-import { postMessageToBackend } from "./figmaUtils";
-import { EnhancedIssuesStore, IssueType, IssueX, Routes } from "./types";
+import { MESSAGE_TYPES } from "../constants";
+import { postMessageToBackend } from "../figmaUtils";
+import { EnhancedIssuesStore, IssueType, IssueX, Routes } from "../types";
 
 const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
   issues: [],


### PR DESCRIPTION
## Summary
- `navigateToIssue` in `src/lib/useIssuesStore.ts` was still building a raw `parent.postMessage({ pluginMessage: { type: "navigate", ... } }, "*")` call, left over from before message types were centralized in `MESSAGE_TYPES` (#21). Flagged in `roadmap/IMPROVEMENT_IDEAS.md`.
- Replaced with the existing `postMessageToBackend(MESSAGE_TYPES.NAVIGATE, { id })` helper, matching the pattern already used elsewhere in the same store (e.g. `startScan`). The message shape sent to the plugin sandbox is unchanged.
- Added test coverage for `navigateToIssue` (previously untested): posts `MESSAGE_TYPES.NAVIGATE` with the target node's id and advances `currentIndex`; no-ops on an out-of-range or negative index. `postMessageToBackend` is mocked via `vi.mock` + `vi.hoisted`. Verified the test actually catches a regression (temporarily made it navigate to the wrong node, confirmed the test failed, then restored the fix).
- Per AGENTS.md's file-structure rule (utility/hook modules touched significantly move into their own folder with a colocated `index.test.ts`, same as `utils/` and `figmaUtils/` in #23): moved `src/lib/useIssuesStore.ts` -> `src/lib/useIssuesStore/index.ts`. No importer changes needed — `moduleResolution: "bundler"` resolves `@/lib/useIssuesStore` straight to the new `index.ts`.

## Test plan
- [x] `npm run test` — 37/37 passing, including the 3 new `navigateToIssue` tests.
- [x] `npx eslint src/**/*.{js,jsx,ts,tsx} --max-warnings=0` passes.
- [x] `npx tsc -b` passes.
- [x] `npm run build` — both the Vite UI bundle and the esbuild plugin bundle build cleanly.
- [x] Confirmed the new test fails when the underlying logic is broken (not just a trivially-passing assertion).
- [ ] Manual verification in Figma dev mode (clicking through an issue list and confirming the viewport still navigates) is still recommended before merge, since this is UI/plugin-runtime behavior vitest can't exercise directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)