### PR TITLE
fix: narrow EnhancedIssuesStore.selectedType from string to IssueType | ""

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,7 +70,7 @@ export interface IssuesStore {
 export interface EnhancedIssuesStore extends IssuesStore {
   singleIssue: IssueX | null; // An issue instance
   scanning: boolean;
-  selectedType: string; // Selected issue type
+  selectedType: IssueType | ""; // Selected issue type; "" means no scan has run yet
   currentRoute: Routes;
   setScanning: (isScanning: boolean) => void; // Setter for scanning state
   setSingleIssue: (newIssue: IssueX | null) => void; // Setter for a single issue


### PR DESCRIPTION
## Summary
- `selectedType` (`src/lib/useIssuesStore`'s `EnhancedIssuesStore`, `src/lib/types.ts`) was typed as a bare `string`, so any typo or arbitrary value (e.g. `"Contrsat"`) would silently type-check and only fail at runtime when nothing matched in `getIssueGroupList`'s filter. Flagged in `roadmap/IMPROVEMENT_IDEAS.md`.
- Narrowed to `IssueType | ""`, keeping `""` as the deliberate "no scan run yet" initial-state sentinel (that behaviour is unchanged) while rejecting anything else at compile time.
- `setSelectedType(type: IssueType)` and all read sites (`IssuesWrapper.tsx`, `IssuesNavigator.tsx`, `TouchTargetNavigator.tsx`, `getIssueGroupList`) already treated the value as string-compatible, so no other code changes were needed.

## Test plan
- Type-only change with no runtime behaviour difference, so this isn't vitest-testable — verified via `tsc` instead:
  - [x] Proved the fix actually rejects invalid values: temporarily added `store.selectedType = "banana"` and confirmed it failed to compile; reverted.
  - [x] Proved the deliberate `""` sentinel still compiles.
  - [x] `npx tsc -b` passes.
  - [x] `npm run test` — 37/37 passing, unaffected.
  - [x] `npx eslint src/**/*.{js,jsx,ts,tsx} --max-warnings=0` passes.
  - [x] `npm run build` — both the Vite UI bundle and the esbuild plugin bundle build cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)