### PR TITLE
chore: remove @ts-nocheck from plugin/code.ts, give it its own tsconfig

### DIFF
--- a/plugin/code.ts
+++ b/plugin/code.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
+/// <reference types="@figma/plugin-typings" />
 
 import { isLocked, isVisible } from "@create-figma-plugin/utilities";
 

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -1,19 +1,22 @@
 {
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "tsBuildInfoFile": "../node_modules/.tmp/tsconfig.plugin.tsbuildinfo",
     "target": "ES2020",
-    "useDefineForClassFields": true,
+    /* code.ts itself never touches the DOM (no DOM in the Figma sandbox),
+       but it transitively imports shared src/lib modules (figmaUtils,
+       utils) that are also used by the DOM-having UI - e.g. utils'
+       copyToClipboard uses document/navigator. TS checks a whole file
+       once it's in the program, so DOM has to stay here too. */
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "allowJs": true,
-    "baseUrl": ".",
+    "baseUrl": "..",
     "paths": {
       "@/*": ["./src/*"]
     },
 
     /* figma plugin types */
-    "typeRoots": ["./node_modules/@types", "./node_modules/@figma"],
+    "typeRoots": ["../node_modules/@types", "../node_modules/@figma"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",
@@ -21,7 +24,6 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
-    "jsx": "react-jsx",
 
     /* Linting */
     "strict": true,
@@ -30,5 +32,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src", "config"]
+  "include": ["code.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "files": [],
-  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" },
+    { "path": "./plugin/tsconfig.json" }
+  ],
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Summary
- `plugin/code.ts` had `// @ts-nocheck` at the top, excluding it entirely from type checking despite being the file doing the most direct Figma API work. Flagged in `roadmap/IMPROVEMENT_IDEAS.md`.
- Removing it surfaces **zero** type errors under the project's real build config. Verified this wasn't a false negative by temporarily introducing a typo (`textNode.fontNameTypo`) and confirming `npm run build` fails at the `tsc -b` step with a real diagnostic, then restoring it.
- Split `plugin/code.ts` into its own `plugin/tsconfig.json` (referenced from the root `tsconfig.json`, dropped from `tsconfig.app.json`'s `include`), instead of relying on the solution-style root config (`"files": []` + only `"references"`) to somehow route it through `tsconfig.app.json`'s bare `"plugin"` include entry. That setup left editors unable to reliably resolve which project owns `plugin/code.ts` - VS Code showed a false `Cannot find name 'figma'` on line 20 even though `tsc -b` was clean, and persisted through both a TS server restart and a full window reload.
  - Kept `DOM`/`DOM.Iterable` in the new project's `lib` rather than restricting it to the Figma sandbox's actual DOM-less environment: `plugin/code.ts` transitively imports shared `src/lib` modules (`figmaUtils`, `utils`) also used by the UI - e.g. `utils`' `copyToClipboard` uses `document`/`navigator` - and TypeScript checks a whole file once it's part of the program, not just the exports actually used by the importer. Verified this empirically (dropping DOM broke `figmaUtils`'s `parent.postMessage` and `utils`' `document`/`navigator` usage) before deciding to keep it.
  - Added `/// <reference types="@figma/plugin-typings" />` directly to `plugin/code.ts`, since `typeRoots` auto-inclusion proved less reliably honored by VS Code's language service than an explicit reference directive for a tsconfig living outside the repo root - this is what actually cleared the editor-side false positive after the dedicated tsconfig alone didn't.

## Test plan
- [x] `npm run test` - 37/37 passing, unaffected.
- [x] `npx eslint src/**/*.{js,jsx,ts,tsx} --max-warnings=0` and `npx eslint plugin/*.ts --max-warnings=0` both pass.
- [x] `npx tsc -b` and `npm run build` (full: `tsc -b && vite build && esbuild`) both pass clean.
- [x] Confirmed `npm run build` actually fails on a real type error in `plugin/code.ts` (not just a no-op check) via a temporary typo, then restored.
- [x] Confirmed in VS Code directly: the false `Cannot find name 'figma'` error is gone after this change (required a full window reload, not just a TS server restart, plus the explicit reference directive - a dedicated tsconfig alone wasn't sufficient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)