### PR TITLE
fix: consolidate severity colours onto getSeverityStyles

### DIFF
--- a/src/components/organisms/IssuesOverviewList.tsx
+++ b/src/components/organisms/IssuesOverviewList.tsx
@@ -4,6 +4,7 @@ import { ISSUES_TYPES, MESSAGE_TYPES } from "@/lib/constants";
 import { ISSUES_DATA_SCHEMA } from "@/lib/issuesData";
 import { IssueType, IssueX } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
+import { cn, getSeverityStyles } from "@/lib/utils";
 import { saveAs } from "file-saver";
 import { ChevronLeft, ChevronRight, RefreshCcw } from "lucide-react";
 import Separator from "../ui/separator";
@@ -222,26 +223,20 @@ export default function IssuesOverviewList() {
 
                             <div className="flex w-auto items-center justify-end space-x-2">
                               <span
-                                className={`rounded px-1.5 py-0.5 text-xs tracking-wide text-dark-shade
-                           ${
-                             issue.severity === "critical"
-                               ? "bg-red-500"
-                               : issue.severity === "major"
-                                 ? "bg-orange-500"
-                                 : "bg-amber-500"
-                           }
-                            `}
+                                className={cn(
+                                  "rounded px-1.5 py-0.5 text-xs tracking-wide",
+                                  getSeverityStyles(issue.severity, {
+                                    isBadge: true,
+                                  }),
+                                )}
                               >
                                 {issueCount}
                               </span>
                               <span
-                                className={`text-xs !capitalize ${
-                                  issue.severity === "critical"
-                                    ? "text-red-500"
-                                    : issue.severity === "major"
-                                      ? "text-orange-500"
-                                      : "text-amber-500"
-                                }`}
+                                className={cn(
+                                  "text-xs !capitalize",
+                                  getSeverityStyles(issue.severity),
+                                )}
                               >
                                 {issue.severity}
                               </span>

--- a/src/components/organisms/TouchTargetNavigator.tsx
+++ b/src/components/organisms/TouchTargetNavigator.tsx
@@ -136,11 +136,10 @@ export default function TouchTargetNavigator() {
           label="Severity:"
           value={
             <span
-              className={cn("font-bold capitalize text-base", {
-                "text-rose-600": severity === "critical",
-                "text-orange-500": severity === "major",
-                "text-amber-500": severity === "minor",
-              })}
+              className={cn(
+                "capitalize text-base",
+                getSeverityStyles(severity, { isBold: true }),
+              )}
             >
               {severity}
             </span>

--- a/src/lib/utils/index.test.ts
+++ b/src/lib/utils/index.test.ts
@@ -5,6 +5,7 @@ import {
   copyToClipboard,
   getBackgroundColorForNode,
   getContrastCompliance,
+  getSeverityStyles,
 } from "./index";
 
 const WHITE: RGBColor = [255, 255, 255];
@@ -218,5 +219,47 @@ describe("getBackgroundColorForNode", () => {
     );
 
     expect(getBackgroundColorForNode(node)).toBeNull();
+  });
+});
+
+describe("getSeverityStyles", () => {
+  it("returns the base text colour for each severity", () => {
+    expect(getSeverityStyles("critical")).toBe("text-rose-500");
+    expect(getSeverityStyles("major")).toBe("text-orange-500");
+    expect(getSeverityStyles("minor")).toBe("text-amber-500");
+  });
+
+  it("returns an empty string for an unrecognised or missing severity", () => {
+    expect(getSeverityStyles(undefined)).toBe("");
+    expect(getSeverityStyles("not-a-severity")).toBe("");
+  });
+
+  it("adds font-bold when isBold is set", () => {
+    expect(getSeverityStyles("critical", { isBold: true })).toBe(
+      "text-rose-500 font-bold",
+    );
+  });
+
+  it("returns the filled circular icon treatment when isIcon is set, overriding the base text colour", () => {
+    expect(getSeverityStyles("major", { isIcon: true })).toBe(
+      "mr-3 size-5 rounded-full bg-orange-600 p-1 text-dark-shade",
+    );
+  });
+
+  it("returns a solid badge (background colour, dark text) when isBadge is set, overriding the base text colour", () => {
+    // Regression guard for the bug this replaced: IssuesOverviewList.tsx used
+    // to hardcode its own bg-{severity}-500 classes inline, independently of
+    // this helper, which is exactly the kind of drift a single source of
+    // truth is meant to prevent (it had drifted to a different red for
+    // "critical": bg-red-500 here vs text-rose-500 in this helper).
+    expect(getSeverityStyles("critical", { isBadge: true })).toBe(
+      "bg-rose-500 text-dark-shade",
+    );
+    expect(getSeverityStyles("major", { isBadge: true })).toBe(
+      "bg-orange-500 text-dark-shade",
+    );
+    expect(getSeverityStyles("minor", { isBadge: true })).toBe(
+      "bg-amber-500 text-dark-shade",
+    );
   });
 });

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -23,7 +23,8 @@ export const getSeverityStyles = (
   {
     isIcon = false,
     isBold = false,
-  }: { isIcon?: boolean; isBold?: boolean } = {},
+    isBadge = false,
+  }: { isIcon?: boolean; isBold?: boolean; isBadge?: boolean } = {},
 ) => {
   const baseStyles = {
     critical: "text-rose-500",
@@ -43,10 +44,17 @@ export const getSeverityStyles = (
     minor: "mr-3 size-5 rounded-full bg-amber-500 p-1 text-dark-shade",
   };
 
+  const badgeStyles = {
+    critical: "bg-rose-500 text-dark-shade",
+    major: "bg-orange-500 text-dark-shade",
+    minor: "bg-amber-500 text-dark-shade",
+  };
+
   return cn(
     baseStyles[(severity as keyof typeof baseStyles) ?? ""] || "",
     isBold && boldStyles[(severity as keyof typeof baseStyles) ?? ""],
     isIcon && iconStyles[(severity as keyof typeof baseStyles) ?? ""],
+    isBadge && badgeStyles[(severity as keyof typeof baseStyles) ?? ""],
   );
 };
 


### PR DESCRIPTION
## Summary
- Three different, drifted definitions of "which colour is critical/major/minor" existed across the codebase: the canonical `getSeverityStyles` helper (`rose-500`), `IssuesOverviewList.tsx`'s own inline ternary (`red-500`), and `TouchTargetNavigator.tsx`'s separate inline ternary (`rose-600`). Flagged in `roadmap/UI_AUDIT.md`.
- Both duplicates now call `getSeverityStyles` instead of reimplementing the colour logic, so there's one source of truth.
- `getSeverityStyles` gains a new `isBadge` option (`bg-{severity}-500 text-dark-shade`) to cover `IssuesOverviewList.tsx`'s rectangular count-badge use case, alongside the existing plain-text and circular-icon variants.
- Added test coverage for `getSeverityStyles`, which previously had none — base/bold/icon/badge variants, including a regression-guard case verifying `tailwind-merge` correctly resolves the base-text-colour vs. badge/icon conflict.

## Test plan
- [x] `npm run test` — 42/42 passing.
- [x] `npx eslint src/**/*.{js,jsx,ts,tsx} --max-warnings=0` passes.
- [x] `npx tsc -b` passes.
- [x] `npm run build` — both the Vite UI bundle and the esbuild plugin bundle build cleanly.
- [ ] Manual visual verification in Figma dev mode still outstanding (confirming the badge/label colours actually render correctly) — build/lint/test passing isn't proof of correctness for a visual-only change.