### PR TITLE
feat: add contrast colour swatches and truncated-name tooltips

### DIFF
--- a/src/components/organisms/IssuesNavigator.tsx
+++ b/src/components/organisms/IssuesNavigator.tsx
@@ -5,8 +5,8 @@ import { MESSAGE_TYPES, MIN_FONT_SIZE } from "@/lib/constants";
 import { postMessageToBackend } from "@/lib/figmaUtils";
 import { IssueX } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
-import { cn, getSeverityStyles } from "@/lib/utils";
-import { CaseSensitive, Check, OctagonAlert, X } from "lucide-react";
+import { cn, figmaRGBtoHex, getSeverityStyles } from "@/lib/utils";
+import { CaseSensitive, Check, OctagonAlert, Palette, X } from "lucide-react";
 
 export default function IssuesNavigator() {
   const {
@@ -55,7 +55,14 @@ export default function IssuesNavigator() {
     }
 
     const { type, severity } = issue;
-    const { characters, fontSize, contrastScore, id } = issue.nodeData ?? {};
+    const {
+      characters,
+      fontSize,
+      contrastScore,
+      id,
+      foregroundColor,
+      backgroundColor,
+    } = issue.nodeData ?? {};
     const getFontSize = () => fontSize ?? singleIssue?.nodeData?.fontSize ?? 0;
     const fontSizeIsValid = getFontSize() >= MIN_FONT_SIZE;
 
@@ -65,7 +72,10 @@ export default function IssuesNavigator() {
           icon={<CaseSensitive className="mr-3 size-5" />}
           label="Text:"
           value={
-            <span className="line-clamp-1 w-full max-w-[10.938rem] text-right font-mono">
+            <span
+              title={characters}
+              className="line-clamp-1 w-full max-w-[10.938rem] text-right font-mono"
+            >
               {characters}
             </span>
           }
@@ -132,6 +142,42 @@ export default function IssuesNavigator() {
 
         {type === "Contrast" && (
           <>
+            {foregroundColor && (
+              <IssueDetailRow
+                icon={<Palette className="mr-3 size-5" />}
+                label={<span className="text-sm">Text colour:</span>}
+                value={
+                  <span className="ml-2.5 inline-flex items-center gap-x-2 font-mono text-sm">
+                    <span
+                      className="size-4 shrink-0 rounded border border-white/20"
+                      style={{
+                        backgroundColor: figmaRGBtoHex(foregroundColor),
+                      }}
+                    />
+                    {figmaRGBtoHex(foregroundColor)}
+                  </span>
+                }
+              />
+            )}
+
+            {backgroundColor && (
+              <IssueDetailRow
+                icon={<Palette className="mr-3 size-5" />}
+                label={<span className="text-sm">Background colour:</span>}
+                value={
+                  <span className="ml-2.5 inline-flex items-center gap-x-2 font-mono text-sm">
+                    <span
+                      className="size-4 shrink-0 rounded border border-white/20"
+                      style={{
+                        backgroundColor: figmaRGBtoHex(backgroundColor),
+                      }}
+                    />
+                    {figmaRGBtoHex(backgroundColor)}
+                  </span>
+                }
+              />
+            )}
+
             <IssueDetailRow
               icon={
                 contrastScore?.compliance === "Fail" ? (

--- a/src/components/organisms/TouchTargetNavigator.tsx
+++ b/src/components/organisms/TouchTargetNavigator.tsx
@@ -40,7 +40,10 @@ export default function TouchTargetNavigator() {
           icon={<Target className="mr-3 size-5" />}
           label="Element:"
           value={
-            <span className="w-full max-w-44 truncate text-right font-mono text-sm">
+            <span
+              title={characters ?? name}
+              className="w-full max-w-44 truncate text-right font-mono text-sm"
+            >
               {characters ?? name}
             </span>
           }


### PR DESCRIPTION
## Summary
- `IssuesNavigator.tsx`'s Contrast issue detail showed only numbers (WCAG score, contrast ratio) — never the actual foreground/background colours in question, so users had to go find the layer in Figma to see them. Flagged in `roadmap/UI_AUDIT.md`.
- Adds "Text colour:"/"Background colour:" rows with a swatch plus hex value, via the existing `figmaRGBtoHex` helper — no new colour-conversion logic needed. Also lays the groundwork for `roadmap/COLOR_FIX_SUGGESTER_PLAN.md` if that gets picked up later.
- Adds native `title` tooltips to the truncated element/text name values in `IssuesNavigator.tsx` and `TouchTargetNavigator.tsx`, so the full value is visible on hover instead of a silent ellipsis with no way to see the rest.

## Test plan
- [x] `npm run test` — 37/37 passing (unaffected; this PR doesn't touch test-covered logic, just presentational JSX).
- [x] `npx eslint src/**/*.{js,jsx,ts,tsx} --max-warnings=0` passes.
- [x] `npx tsc -b` passes.
- [x] `npm run build` — both the Vite UI bundle and the esbuild plugin bundle build cleanly.
- [ ] Manual visual verification in Figma dev mode still outstanding (confirming the swatches render the correct colours and the tooltips work) — build/lint/test passing isn't proof of correctness for a visual-only change.