### PR TITLE
ci: add GitHub Actions workflow for lint, typecheck, test, build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,17 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout code
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
 
-      - run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc -b
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- There was no server-side gate on PRs — only the local Husky pre-commit/commit-msg hooks, which can be bypassed. Flagged in `roadmap/IMPROVEMENT_IDEAS.md`.
- Adds `.github/workflows/ci.yml`, running on `pull_request` (targeting `main`) and `push` to `main`: `npm run lint`, `tsc -b` (typecheck across both the UI project and the plugin-sandbox project set up in #27), `npm run test`, and `npm run build` (the full build: `tsc -b && vite build && esbuild`).
- Node 24, matching the local dev environment (no `.nvmrc`/`engines` field existed to pin against).

## Note
- `npm run lint`'s glob only covers `src/**` — it doesn't lint `plugin/code.ts`. That's pre-existing (not something this PR changes), so CI mirrors the same gap the local `npm run lint` has today. Worth a separate follow-up if `plugin/` linting should be added, now that it's fully typed (#27) — didn't want to bundle an unrelated lint-scope change into this PR.
- Once this merges and the workflow has run at least once, the `ci` check can be added as a required status check in branch protection to actually close the "no server-side gate" gap — happy to do that next if wanted.

## Test plan
- [x] Ran the exact same four commands locally against current `main` before opening this PR: `npm run lint`, `npx tsc -b`, `npm run test` (42/42 passing), `npm run build` — all pass clean.
- [ ] The workflow itself will get its first real verification once GitHub Actions runs it on this PR.