### PR TITLE
feat: add category breakdown chart to the Report tab

### DIFF
--- a/src/components/organisms/IssueBreakdownChart.tsx
+++ b/src/components/organisms/IssueBreakdownChart.tsx
@@ -1,0 +1,64 @@
+import Progress from "@/components/ui/progress";
+import { IssueType } from "@/lib/types";
+
+/**
+ * Fixed-order categorical palette (blue/orange/aqua/yellow, slots 1-4 of the
+ * validated 8-hue set) - validated with the dataviz skill's palette
+ * validator against this app's actual dark card surface (#232325):
+ * all pairs clear both the CVD (>=8) and normal-vision (>=15) floors.
+ * Assigned by identity, never cycled/reordered.
+ */
+const ISSUE_TYPE_CHART_COLORS: Record<IssueType, string> = {
+  Contrast: "#3987e5",
+  Typography: "#d95926",
+  "Touch Target Size": "#199e70",
+  "Touch Target Spacing": "#c98500",
+};
+
+export type IssueBreakdownChartItem = {
+  type: IssueType;
+  count: number;
+};
+
+export type IssueBreakdownChartProps = {
+  items: IssueBreakdownChartItem[];
+};
+
+export default function IssueBreakdownChart({
+  items,
+}: IssueBreakdownChartProps) {
+  const maxCount = Math.max(...items.map((item) => item.count), 1);
+  const summary = items.map((item) => `${item.type}: ${item.count}`).join(", ");
+
+  return (
+    <div
+      role="img"
+      aria-label={`Issues by category — ${summary}`}
+      className="space-y-3"
+    >
+      {items.map((item) => {
+        const color = ISSUE_TYPE_CHART_COLORS[item.type];
+
+        return (
+          <div key={item.type} aria-hidden="true">
+            <div className="mb-1 flex items-center justify-between text-sm">
+              <span className="inline-flex items-center gap-x-1.5">
+                <span
+                  className="size-2.5 shrink-0 rounded-full"
+                  style={{ backgroundColor: color }}
+                />
+                <span className="text-grey">{item.type}</span>
+              </span>
+              <span className="font-medium">{item.count}</span>
+            </div>
+            <Progress
+              value={(item.count / maxCount) * 100}
+              className="h-2 bg-dark"
+              indicatorStyle={{ backgroundColor: color }}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/organisms/IssuesOverviewList.tsx
+++ b/src/components/organisms/IssuesOverviewList.tsx
@@ -8,6 +8,7 @@ import { cn, getSeverityStyles } from "@/lib/utils";
 import { saveAs } from "file-saver";
 import { ChevronLeft, ChevronRight, RefreshCcw } from "lucide-react";
 import Separator from "../ui/separator";
+import IssueBreakdownChart from "./IssueBreakdownChart";
 import LoadingScreen from "./LoadingScreen";
 
 export default function IssuesOverviewList() {
@@ -61,6 +62,13 @@ export default function IssuesOverviewList() {
   const issuesGroup = ISSUES_DATA_SCHEMA.filter((issue) =>
     issues?.some((i: IssueX) => i.type === issue.type),
   );
+
+  const breakdownItems = issuesGroup
+    .map((issue) => ({
+      type: issue.type as IssueType,
+      count: issuesGroupListRecords.filter((i) => i.type === issue.type).length,
+    }))
+    .filter((item) => item.count > 0);
 
   // Convert issues to structured data for reporting
   const formatIssuesForReport = () => {
@@ -273,6 +281,16 @@ export default function IssuesOverviewList() {
                 Generate a detailed report of all identified issues and
                 suggestions.
               </p>
+
+              {breakdownItems.length > 0 && (
+                <div className="mb-5 rounded-xl bg-dark-shade p-4">
+                  <h4 className="mb-3 text-sm font-medium text-grey">
+                    Issues by category
+                  </h4>
+                  <IssueBreakdownChart items={breakdownItems} />
+                </div>
+              )}
+
               <div className="space-x-3">
                 <Button
                   title="Download CSV Report"

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -2,10 +2,17 @@ import * as React from "react";
 import * as ProgressPrimitive from "@radix-ui/react-progress";
 import { cn } from "@/lib/utils";
 
+export type ProgressProps = React.ComponentPropsWithoutRef<
+  typeof ProgressPrimitive.Root
+> & {
+  indicatorClassName?: string;
+  indicatorStyle?: React.CSSProperties;
+};
+
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+  ProgressProps
+>(({ className, value, indicatorClassName, indicatorStyle, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
@@ -15,8 +22,14 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="size-full flex-1 bg-accent transition-all dark:bg-stone-50"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      className={cn(
+        "size-full flex-1 bg-accent transition-all dark:bg-stone-50",
+        indicatorClassName,
+      )}
+      style={{
+        transform: `translateX(-${100 - (value || 0)}%)`,
+        ...indicatorStyle,
+      }}
     />
   </ProgressPrimitive.Root>
 ));


### PR DESCRIPTION
## Summary
- The Report tab had two download buttons and a lot of empty space, despite the Issues tab already having this data grouped and counted by category. Flagged in `roadmap/UI_AUDIT.md`.
- Adds a horizontal bar chart (`IssueBreakdownChart.tsx`) showing issue count per category, built per the dataviz skill's procedure (loaded before writing any chart code).

## Colour: type, not severity — and why
Checked the app's existing severity palette (`rose-500`/`orange-500`/`amber-500`) against the skill's `validate_palette.js` first, rather than assuming it was fine. It **hard-fails the normal-vision floor**: major vs. minor measures ΔE 9.6 (need ≥15) — i.e. even someone with fully typical colour vision struggles to tell them apart. Re-stepping individual steps didn't fully fix it either (critical vs. major then fails at ΔE 12.7). The skill's own reference status palette isn't built for multiple status colours shown side-by-side either — it's designed for one status + icon at a time, per its own documentation.

Issue *type* (Contrast/Typography/Touch Target Size/Touch Target Spacing) is a genuine categorical/identity encoding, which the skill's categorical palette *is* built and validated for — so that's the dimension the chart encodes instead. Uses slots 1-4 (blue/orange/aqua/yellow) of the skill's validated 8-hue set, in fixed order (assigned by identity, never cycled), re-validated with `validate_palette.js` against this app's actual dark card surface (`#232325`) rather than trusting the skill's default surface: all checks pass (worst adjacent pair CVD ΔE 8.4, normal-vision ΔE 19.8).

## Implementation
- Each row direct-labels its category (colour swatch + name + count) — satisfies "identity never from colour alone" without a separate legend box, which the skill allows for ≤4 categories.
- Reuses `src/components/ui/progress.tsx` (a shadcn primitive that was installed but had **zero usage sites anywhere in the app**) for the bar track/fill, extended with optional `indicatorClassName`/`indicatorStyle` props — backward compatible, nothing to break — instead of hand-rolling a parallel bar implementation.
- The existing Issues tab list (same data, same counts) serves as the "table view" the skill's accessibility pass calls for; the chart's wrapping div also carries a full-text `aria-label` summary for screen readers.

## Test plan
- [x] `npm run test` — 42/42 passing (unaffected; no logic under test changed).
- [x] `npx eslint src/**/*.{js,jsx,ts,tsx} --max-warnings=0` passes.
- [x] `npx tsc -b` passes.
- [x] `npm run build` — both bundles build cleanly.
- [x] Colour palette validated with the skill's actual validator script against the app's real surface (see above) — not eyeballed.
- [ ] No screenshot/render tool was available in this environment, so the skill's "open or screenshot and eyeball it" step (label collisions, geometry, overflow) couldn't be done here. Flagging that as outstanding, alongside the manual Figma verification every other UI PR this session has needed.