### PR TITLE
refactor: dedupe touch-target node-type list, type it against Figma

### DIFF
--- a/src/lib/issuesData.tsx
+++ b/src/lib/issuesData.tsx
@@ -2,6 +2,23 @@ import { Contrast, MoveHorizontal, Pointer, TypeOutline } from "lucide-react";
 import { MIN_FONT_SIZE } from "./constants";
 import { Issue, IssueRecommendations } from "./types";
 
+/**
+ * Node types a touch-target issue (size or spacing) can apply to. Shared
+ * by both ISSUES_DATA_SCHEMA entries below instead of repeating the list.
+ */
+const TOUCH_TARGET_NODE_TYPES: NodeType[] = [
+  "COMPONENT",
+  "COMPONENT_SET",
+  "ELLIPSE",
+  "FRAME",
+  "GROUP",
+  "INSTANCE",
+  "POLYGON",
+  "RECTANGLE",
+  "VECTOR",
+  "WIDGET",
+];
+
 const ISSUES_DATA_SCHEMA: Issue[] = [
   {
     id: 1,
@@ -34,18 +51,7 @@ const ISSUES_DATA_SCHEMA: Issue[] = [
     type: "TOUCH_TARGET_SIZE",
     description: "Touch target element is smaller than 44px.",
     severity: "minor",
-    nodeType: [
-      "COMPONENT",
-      "COMPONENT_SET",
-      "ELLIPSE",
-      "FRAME",
-      "GROUP",
-      "INSTANCE",
-      "POLYGON",
-      "RECTANGLE",
-      "VECTOR",
-      "WIDGET",
-    ],
+    nodeType: TOUCH_TARGET_NODE_TYPES,
     icon: (
       <Pointer
         strokeWidth={1.5}
@@ -59,18 +65,7 @@ const ISSUES_DATA_SCHEMA: Issue[] = [
     type: "TOUCH_TARGET_SPACING",
     description: "Touch target elements are too close.",
     severity: "minor",
-    nodeType: [
-      "COMPONENT",
-      "COMPONENT_SET",
-      "ELLIPSE",
-      "FRAME",
-      "GROUP",
-      "INSTANCE",
-      "POLYGON",
-      "RECTANGLE",
-      "VECTOR",
-      "WIDGET",
-    ],
+    nodeType: TOUCH_TARGET_NODE_TYPES,
     icon: (
       <MoveHorizontal
         strokeWidth={1.5}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,7 +12,7 @@ export type Issue = {
   type: IssueType;
   description: string;
   severity: Severity;
-  nodeType: string | string[];
+  nodeType: NodeType | NodeType[];
   icon: ReactNode;
 };
 
@@ -44,7 +44,7 @@ export type NodeDataType = {
   name: string;
   foregroundColor?: RGBColor;
   backgroundColor?: RGBColor;
-  nodeType: string | string[];
+  nodeType: NodeType | NodeType[];
   requiredSize?: string;
 };
 


### PR DESCRIPTION
## Summary
The 10-item node-type array in `issuesData.tsx`'s `ISSUES_DATA_SCHEMA` was repeated verbatim across the "Touch Target Size" and "Touch Target Spacing" entries. Extracted into one shared `TOUCH_TARGET_NODE_TYPES` constant.

While looking into it: `ISSUES_DATA_SCHEMA[i].nodeType` doesn't appear to be read anywhere in the app (only `nodeData.nodeType` — a different, runtime field — is actually consumed). Flagged this and asked before proceeding; decided to dedupe + type it rather than remove it, in case it's meant for future use.

Also typed it (and `Issue.nodeType`/`NodeDataType.nodeType` in `types.ts`, previously `string | string[]`) against Figma's own ambient `NodeType` (`BaseNode['type']`, from `@figma/plugin-typings`) instead of plain strings — so a typo in the list is a compile error, not a silent runtime miss. `NodeDataType.nodeType` got the same tightening for consistency (same field name/purpose, previously the only other place with this exact loose typing; already populated from real `node.type` values in `figmaUtils/index.ts`'s issue builders, so nothing else needed to change).

## Test plan
- [x] `npm run test` — 44/44 passing.
- [x] `npx eslint src/**/*.{js,jsx,ts,tsx} --max-warnings=0` passes.
- [x] `npx tsc --noEmit -p tsconfig.app.json` / `plugin/tsconfig.json` / `tsconfig.node.json` all pass, verified with cleared `.tsbuildinfo` caches (not just `tsc -b`, after learning that can false-pass on stale cache in this repo).
- [x] Proved the new typing actually catches mistakes rather than just asserting it: introduced a deliberate typo (`"RECTANGEL"`), confirmed `tsc` rejected it (and even suggested the correct spelling: `Did you mean '"RECTANGLE"'?`), then restored it.
- [x] `npm run build` — both bundles build cleanly.