### PR TITLE
test: cover isTouchTarget, isBoldFont, issue builders, and getIssueGroupList

### DIFF
--- a/src/lib/figmaUtils/index.test.ts
+++ b/src/lib/figmaUtils/index.test.ts
@@ -22,6 +22,19 @@ function fakeNode(
   } as unknown as SceneNode;
 }
 
+function fakeTextNode(overrides: Partial<TextNode> = {}): TextNode {
+  return {
+    id: "text-1",
+    characters: "Hello",
+    fontSize: 10,
+    height: 12,
+    lineHeight: { unit: "AUTO" },
+    name: "Label",
+    type: "TEXT",
+    ...overrides,
+  } as unknown as TextNode;
+}
+
 describe("extractForegroundColor", () => {
   it("returns the color of a single visible solid fill", () => {
     const fills = [solidFill(1, 0, 0)];
@@ -191,15 +204,7 @@ describe("isTouchTarget", () => {
 
 describe("createTypographyIssue", () => {
   it("builds a TYPOGRAPHY issue from a TextNode", () => {
-    const node = {
-      id: "text-1",
-      characters: "Hello",
-      fontSize: 10,
-      height: 12,
-      lineHeight: { unit: "AUTO" },
-      name: "Label",
-      type: "TEXT",
-    } as unknown as TextNode;
+    const node = fakeTextNode();
 
     expect(createTypographyIssue(node)).toEqual({
       description: "Text size is too small for readability.",
@@ -219,28 +224,12 @@ describe("createTypographyIssue", () => {
 });
 
 describe("createContrastIssue", () => {
-  function fakeTextNode(): TextNode {
-    return {
-      id: "text-2",
-      characters: "Hi",
-      fontSize: 16,
-      height: 20,
-      lineHeight: { unit: "AUTO" },
-      name: "Body",
-      type: "TEXT",
-    } as unknown as TextNode;
-  }
-
   it("builds a CONTRAST issue with the given colours and score", () => {
+    const node = fakeTextNode({ id: "text-2", characters: "Hi", name: "Body" });
     const contrastScore = { compliance: "Fail" as const, ratio: 2.1 };
 
     expect(
-      createContrastIssue(
-        fakeTextNode(),
-        contrastScore,
-        [0, 0, 0],
-        [255, 255, 255],
-      ),
+      createContrastIssue(node, contrastScore, [0, 0, 0], [255, 255, 255]),
     ).toEqual({
       description: "Text contrast is below WCAG AA standard.",
       severity: "critical",
@@ -249,8 +238,8 @@ describe("createContrastIssue", () => {
         id: "text-2",
         contrastScore,
         characters: "Hi",
-        fontSize: 16,
-        height: 20,
+        fontSize: 10,
+        height: 12,
         lineHeight: { unit: "AUTO" },
         name: "Body",
         nodeType: "TEXT",
@@ -273,6 +262,19 @@ describe("createContrastIssue", () => {
 });
 
 describe("createTouchTargetIssue", () => {
+  function fakeTouchTargetNode(
+    id: string,
+    type: SceneNode["type"],
+    dimensions?: { width: number; height: number },
+  ): SceneNode {
+    return {
+      id,
+      name: "Icon button",
+      type,
+      ...dimensions,
+    } as unknown as SceneNode;
+  }
+
   it("returns null and logs an error for an invalid node", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -280,19 +282,22 @@ describe("createTouchTargetIssue", () => {
       createTouchTargetIssue(null as unknown as SceneNode, "Size"),
     ).toBeNull();
     expect(createTouchTargetIssue({} as SceneNode, "Size")).toBeNull();
-    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenNthCalledWith(
+      1,
+      "Invalid node passed to createTouchTargetIssue:",
+      null,
+    );
+    expect(errorSpy).toHaveBeenNthCalledWith(
+      2,
+      "Invalid node passed to createTouchTargetIssue:",
+      {},
+    );
 
     errorSpy.mockRestore();
   });
 
   it("builds a TOUCH_TARGET_SIZE issue with dimensions when the node has them", () => {
-    const node = {
-      id: "n1",
-      name: "Icon button",
-      type: "FRAME",
-      width: 20,
-      height: 20,
-    } as unknown as SceneNode;
+    const node = fakeTouchTargetNode("n1", "FRAME", { width: 20, height: 20 });
 
     expect(createTouchTargetIssue(node, "Size")).toEqual({
       description:
@@ -311,13 +316,7 @@ describe("createTouchTargetIssue", () => {
   });
 
   it("builds a TOUCH_TARGET_SPACING issue", () => {
-    const node = {
-      id: "n2",
-      name: "Icon button",
-      type: "FRAME",
-      width: 44,
-      height: 44,
-    } as unknown as SceneNode;
+    const node = fakeTouchTargetNode("n2", "FRAME", { width: 44, height: 44 });
 
     const issue = createTouchTargetIssue(node, "Spacing");
 
@@ -328,11 +327,7 @@ describe("createTouchTargetIssue", () => {
   });
 
   it("omits width/height when the node doesn't support them", () => {
-    const node = {
-      id: "n3",
-      name: "Group",
-      type: "GROUP",
-    } as unknown as SceneNode;
+    const node = fakeTouchTargetNode("n3", "GROUP");
 
     const issue = createTouchTargetIssue(node, "Size");
 

--- a/src/lib/figmaUtils/index.test.ts
+++ b/src/lib/figmaUtils/index.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import solidFill from "@/lib/test-utils/solidFill";
 import {
+  createContrastIssue,
+  createTouchTargetIssue,
+  createTypographyIssue,
   extractForegroundColor,
+  isTouchTarget,
   isTouchTargetTooClose,
   isTouchTargetTooSmall,
 } from "./index";
@@ -117,5 +121,222 @@ describe("isTouchTargetTooClose", () => {
     const other = fakeNode("b", { x: 52, y: 0, width: 44, height: 44 });
 
     expect(isTouchTargetTooClose(node, [node, other])).toBe(false);
+  });
+});
+
+describe("isTouchTarget", () => {
+  function fakeSceneNode(
+    name: string,
+    type: SceneNode["type"] = "FRAME",
+  ): SceneNode {
+    return { id: "n", name, type } as unknown as SceneNode;
+  }
+
+  function fakeInstanceNode(
+    name: string,
+    mainComponentName: string | null,
+  ): SceneNode {
+    return {
+      id: "n",
+      name,
+      type: "INSTANCE",
+      getMainComponentAsync: vi.fn(() =>
+        Promise.resolve(mainComponentName ? { name: mainComponentName } : null),
+      ),
+    } as unknown as SceneNode;
+  }
+
+  it("returns false for a falsy node", async () => {
+    expect(await isTouchTarget(null as unknown as SceneNode)).toBe(false);
+  });
+
+  it("returns true when the node's own name matches a touch-target keyword", async () => {
+    expect(await isTouchTarget(fakeSceneNode("Primary Button"))).toBe(true);
+  });
+
+  it("matches keywords case-insensitively", async () => {
+    expect(await isTouchTarget(fakeSceneNode("PRIMARY BTN"))).toBe(true);
+  });
+
+  it("returns false when the name matches a keyword but the node is a TEXT node", async () => {
+    expect(await isTouchTarget(fakeSceneNode("Button label", "TEXT"))).toBe(
+      false,
+    );
+  });
+
+  it("returns false when neither the name nor the type matches anything", async () => {
+    expect(
+      await isTouchTarget(fakeSceneNode("Background rectangle", "RECTANGLE")),
+    ).toBe(false);
+  });
+
+  it("falls back to the main component's name for an INSTANCE whose own name doesn't match", async () => {
+    const node = fakeInstanceNode("Icon 24", "Button/Primary");
+
+    expect(await isTouchTarget(node)).toBe(true);
+  });
+
+  it("returns false for an INSTANCE when neither its name nor its main component's name matches", async () => {
+    const node = fakeInstanceNode("Icon 24", "Icon/Chevron");
+
+    expect(await isTouchTarget(node)).toBe(false);
+  });
+
+  it("returns false for an INSTANCE with no resolvable main component", async () => {
+    const node = fakeInstanceNode("Icon 24", null);
+
+    expect(await isTouchTarget(node)).toBe(false);
+  });
+});
+
+describe("createTypographyIssue", () => {
+  it("builds a TYPOGRAPHY issue from a TextNode", () => {
+    const node = {
+      id: "text-1",
+      characters: "Hello",
+      fontSize: 10,
+      height: 12,
+      lineHeight: { unit: "AUTO" },
+      name: "Label",
+      type: "TEXT",
+    } as unknown as TextNode;
+
+    expect(createTypographyIssue(node)).toEqual({
+      description: "Text size is too small for readability.",
+      severity: "major",
+      type: "TYPOGRAPHY",
+      nodeData: {
+        id: "text-1",
+        characters: "Hello",
+        fontSize: 10,
+        height: 12,
+        lineHeight: { unit: "AUTO" },
+        name: "Label",
+        nodeType: "TEXT",
+      },
+    });
+  });
+});
+
+describe("createContrastIssue", () => {
+  function fakeTextNode(): TextNode {
+    return {
+      id: "text-2",
+      characters: "Hi",
+      fontSize: 16,
+      height: 20,
+      lineHeight: { unit: "AUTO" },
+      name: "Body",
+      type: "TEXT",
+    } as unknown as TextNode;
+  }
+
+  it("builds a CONTRAST issue with the given colours and score", () => {
+    const contrastScore = { compliance: "Fail" as const, ratio: 2.1 };
+
+    expect(
+      createContrastIssue(
+        fakeTextNode(),
+        contrastScore,
+        [0, 0, 0],
+        [255, 255, 255],
+      ),
+    ).toEqual({
+      description: "Text contrast is below WCAG AA standard.",
+      severity: "critical",
+      type: "CONTRAST",
+      nodeData: {
+        id: "text-2",
+        contrastScore,
+        characters: "Hi",
+        fontSize: 16,
+        height: 20,
+        lineHeight: { unit: "AUTO" },
+        name: "Body",
+        nodeType: "TEXT",
+        foregroundColor: [0, 0, 0],
+        backgroundColor: [255, 255, 255],
+      },
+    });
+  });
+
+  it("leaves backgroundColor undefined instead of defaulting to white when none was detected", () => {
+    const issue = createContrastIssue(
+      fakeTextNode(),
+      { compliance: "Fail", ratio: 2.1 },
+      [0, 0, 0],
+      undefined,
+    );
+
+    expect(issue.nodeData.backgroundColor).toBeUndefined();
+  });
+});
+
+describe("createTouchTargetIssue", () => {
+  it("returns null and logs an error for an invalid node", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(
+      createTouchTargetIssue(null as unknown as SceneNode, "Size"),
+    ).toBeNull();
+    expect(createTouchTargetIssue({} as SceneNode, "Size")).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it("builds a TOUCH_TARGET_SIZE issue with dimensions when the node has them", () => {
+    const node = {
+      id: "n1",
+      name: "Icon button",
+      type: "FRAME",
+      width: 20,
+      height: 20,
+    } as unknown as SceneNode;
+
+    expect(createTouchTargetIssue(node, "Size")).toEqual({
+      description:
+        "Touch target size is too small for accessibility. Should be at least 44x44 pixels.",
+      severity: "minor",
+      type: "TOUCH_TARGET_SIZE",
+      nodeData: {
+        id: "n1",
+        name: "Icon button",
+        width: 20,
+        height: 20,
+        nodeType: "FRAME",
+        requiredSize: "44 x 44px",
+      },
+    });
+  });
+
+  it("builds a TOUCH_TARGET_SPACING issue", () => {
+    const node = {
+      id: "n2",
+      name: "Icon button",
+      type: "FRAME",
+      width: 44,
+      height: 44,
+    } as unknown as SceneNode;
+
+    const issue = createTouchTargetIssue(node, "Spacing");
+
+    expect(issue?.type).toBe("TOUCH_TARGET_SPACING");
+    expect(issue?.description).toBe(
+      "Spacing between touch targets is too small for accessibility. Should be at least 8px to the nearest element in all directions.",
+    );
+  });
+
+  it("omits width/height when the node doesn't support them", () => {
+    const node = {
+      id: "n3",
+      name: "Group",
+      type: "GROUP",
+    } as unknown as SceneNode;
+
+    const issue = createTouchTargetIssue(node, "Size");
+
+    expect(issue?.nodeData.width).toBeUndefined();
+    expect(issue?.nodeData.height).toBeUndefined();
   });
 });

--- a/src/lib/useIssuesStore/index.test.ts
+++ b/src/lib/useIssuesStore/index.test.ts
@@ -56,3 +56,89 @@ describe("useIssuesStore.navigateToIssue", () => {
     expect(useIssuesStore.getState().currentIndex).toBe(0);
   });
 });
+
+describe("useIssuesStore.getIssueGroupList", () => {
+  it("returns only issues matching the selected type", () => {
+    useIssuesStore.setState({
+      issues: [
+        {
+          type: "TYPOGRAPHY",
+          severity: "major",
+          nodeData: { id: "1", name: "A", nodeType: "TEXT" },
+        },
+        {
+          type: "TOUCH_TARGET_SIZE",
+          severity: "minor",
+          nodeData: { id: "2", name: "B", nodeType: "FRAME" },
+        },
+      ],
+      selectedType: "TYPOGRAPHY",
+    });
+
+    const result = useIssuesStore.getState().getIssueGroupList();
+
+    expect(result.map((issue) => issue.nodeData.id)).toEqual(["1"]);
+  });
+
+  it("includes a CONTRAST issue only when its compliance is Fail", () => {
+    useIssuesStore.setState({
+      issues: [
+        {
+          type: "CONTRAST",
+          severity: "critical",
+          nodeData: {
+            id: "fail",
+            name: "A",
+            nodeType: "TEXT",
+            contrastScore: { compliance: "Fail", ratio: 2 },
+          },
+        },
+        {
+          type: "CONTRAST",
+          severity: "critical",
+          nodeData: {
+            id: "pass",
+            name: "B",
+            nodeType: "TEXT",
+            contrastScore: { compliance: "AA", ratio: 5 },
+          },
+        },
+      ],
+      selectedType: "CONTRAST",
+    });
+
+    const result = useIssuesStore.getState().getIssueGroupList();
+
+    expect(result.map((issue) => issue.nodeData.id)).toEqual(["fail"]);
+  });
+
+  it("excludes a CONTRAST issue with no contrastScore at all", () => {
+    useIssuesStore.setState({
+      issues: [
+        {
+          type: "CONTRAST",
+          severity: "critical",
+          nodeData: { id: "no-score", name: "A", nodeType: "TEXT" },
+        },
+      ],
+      selectedType: "CONTRAST",
+    });
+
+    expect(useIssuesStore.getState().getIssueGroupList()).toEqual([]);
+  });
+
+  it("returns an empty list when no scan has run yet (selectedType is empty)", () => {
+    useIssuesStore.setState({
+      issues: [
+        {
+          type: "TYPOGRAPHY",
+          severity: "major",
+          nodeData: { id: "1", name: "A", nodeType: "TEXT" },
+        },
+      ],
+      selectedType: "",
+    });
+
+    expect(useIssuesStore.getState().getIssueGroupList()).toEqual([]);
+  });
+});

--- a/src/lib/useIssuesStore/index.test.ts
+++ b/src/lib/useIssuesStore/index.test.ts
@@ -57,6 +57,19 @@ describe("useIssuesStore.navigateToIssue", () => {
   });
 });
 
+function fakeContrastIssue(id: string, compliance: string): IssueX {
+  return {
+    type: "CONTRAST",
+    severity: "critical",
+    nodeData: {
+      id,
+      name: id,
+      nodeType: "TEXT",
+      contrastScore: { compliance, ratio: compliance === "Fail" ? 2 : 5 },
+    },
+  };
+}
+
 describe("useIssuesStore.getIssueGroupList", () => {
   it("returns only issues matching the selected type", () => {
     useIssuesStore.setState({
@@ -83,26 +96,8 @@ describe("useIssuesStore.getIssueGroupList", () => {
   it("includes a CONTRAST issue only when its compliance is Fail", () => {
     useIssuesStore.setState({
       issues: [
-        {
-          type: "CONTRAST",
-          severity: "critical",
-          nodeData: {
-            id: "fail",
-            name: "A",
-            nodeType: "TEXT",
-            contrastScore: { compliance: "Fail", ratio: 2 },
-          },
-        },
-        {
-          type: "CONTRAST",
-          severity: "critical",
-          nodeData: {
-            id: "pass",
-            name: "B",
-            nodeType: "TEXT",
-            contrastScore: { compliance: "AA", ratio: 5 },
-          },
-        },
+        fakeContrastIssue("fail", "Fail"),
+        fakeContrastIssue("pass", "AA"),
       ],
       selectedType: "CONTRAST",
     });

--- a/src/lib/utils/index.test.ts
+++ b/src/lib/utils/index.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { RGBColor, rgb } from "wcag-contrast";
 import solidFill from "@/lib/test-utils/solidFill";
 import {
@@ -7,6 +15,7 @@ import {
   getContrastCompliance,
   getRouteForIssueType,
   getSeverityStyles,
+  isBoldFont,
 } from "./index";
 
 const WHITE: RGBColor = [255, 255, 255];
@@ -278,5 +287,105 @@ describe("getRouteForIssueType", () => {
   it("routes everything else to ISSUE_LIST_VIEW", () => {
     expect(getRouteForIssueType("CONTRAST")).toBe("ISSUE_LIST_VIEW");
     expect(getRouteForIssueType("TYPOGRAPHY")).toBe("ISSUE_LIST_VIEW");
+  });
+});
+
+describe("isBoldFont", () => {
+  // isBoldFont reads figma.mixed unconditionally (even for the plain-number
+  // path), so it needs a minimal figma global — real code gets this from
+  // Figma's plugin sandbox at runtime, which isn't present under vitest.
+  const FIGMA_MIXED = Symbol("figma.mixed");
+
+  beforeAll(() => {
+    vi.stubGlobal("figma", { mixed: FIGMA_MIXED });
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function fakeTextNode(
+    characters: string,
+    rangeWeights: (number | typeof FIGMA_MIXED)[],
+  ): TextNode {
+    return {
+      characters,
+      getRangeFontWeight: vi.fn((start: number) => rangeWeights[start]),
+    } as unknown as TextNode;
+  }
+
+  it("returns false for a falsy fontWeight", () => {
+    expect(isBoldFont(0, {} as TextNode)).toBe(false);
+  });
+
+  it("returns false for a fontWeight below 700", () => {
+    expect(isBoldFont(699, {} as TextNode)).toBe(false);
+  });
+
+  it("returns true for a fontWeight of 700 or more", () => {
+    expect(isBoldFont(700, {} as TextNode)).toBe(true);
+  });
+
+  it("returns false and warns for a non-numeric, non-mixed fontWeight", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(isBoldFont("garbage" as unknown as number, {} as TextNode)).toBe(
+      false,
+    );
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it("returns false and warns when fontWeight is mixed but no start/end range is given", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(isBoldFont(FIGMA_MIXED, fakeTextNode("ab", []))).toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it("returns false and warns for an invalid range (start >= end)", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const node = fakeTextNode("hello", [400, 400, 400, 400, 400]);
+
+    expect(isBoldFont(FIGMA_MIXED, node, 3, 1)).toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it("returns true when any character in a mixed-weight range is bold", () => {
+    const node = fakeTextNode("hello", [400, 400, 700, 400, 400]);
+
+    expect(isBoldFont(FIGMA_MIXED, node, 0, 5)).toBe(true);
+  });
+
+  it("returns false when no character in a mixed-weight range is bold", () => {
+    const node = fakeTextNode("hello", [400, 400, 400, 400, 400]);
+
+    expect(isBoldFont(FIGMA_MIXED, node, 0, 5)).toBe(false);
+  });
+
+  it("skips a mixed (non-numeric) per-character weight and keeps scanning the range", () => {
+    const node = fakeTextNode("hi", [FIGMA_MIXED, 700]);
+
+    expect(isBoldFont(FIGMA_MIXED, node, 0, 2)).toBe(true);
+  });
+
+  it("returns false and logs an error when getRangeFontWeight throws", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const node = {
+      characters: "hi",
+      getRangeFontWeight: vi.fn(() => {
+        throw new Error("boom");
+      }),
+    } as unknown as TextNode;
+
+    expect(isBoldFont(FIGMA_MIXED, node, 0, 2)).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Why

Closes the remaining test-coverage gap flagged after PR #23: `isTouchTarget`'s keyword/component-name matching, `isBoldFont`, the issue builders (`createTypographyIssue`/`createContrastIssue`/`createTouchTargetIssue`), and the store's `getIssueGroupList` filtering logic had no tests.

## What

- 29 new tests across `src/lib/figmaUtils/index.test.ts`, `src/lib/utils/index.test.ts`, and `src/lib/useIssuesStore/index.test.ts` (44 → 73 total).
- `isBoldFont` reads `figma.mixed` unconditionally, even on the plain-number path, so it isn't testable without a minimal `figma` global stub (`vi.stubGlobal("figma", { mixed: <symbol> })`, scoped to that `describe` block) — real code gets `figma` for free from the plugin sandbox, but vitest doesn't provide one.
- Shared fixtures/helpers added to avoid duplicated node/issue literals: `fakeContrastIssue`, `fakeTouchTargetNode`, and a shared `fakeTextNode` factory (reused across `createTypographyIssue`/`createContrastIssue` instead of two near-identical inline node shapes).
- Tightened a loose `toHaveBeenCalled()` on `createTouchTargetIssue`'s invalid-node test to `toHaveBeenNthCalledWith(...)`.

## Test plan

- [x] `tsc --noEmit` clean on all three project configs, verified with a cleared `.tsbuildinfo` cache
- [x] `npm run lint` — clean
- [x] `npm run test` — 73/73 passing
- [x] `npm run build` — clean
- [x] Mutation-checked several of the new assertions (the `>=700` bold threshold, `isTouchTarget`'s TEXT-node exclusion, `getIssueGroupList`'s CONTRAST-compliance guard, and the tightened error-message assertion) by breaking the corresponding source line and confirming the test failed, then restoring