### PR TITLE
feat(ui): add contrast fix suggester with AA/AAA toggle and apply

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,8 @@ Detection logic lives in `plugin/code.ts` (orchestration: `handleScan` for a ful
 
 `handleScan` filters candidate nodes through `isScannable` (`isVisible(node) && !isLocked(node)`, from `@create-figma-plugin/utilities`) so hidden/locked layers are skipped during a full-page scan. `extractForegroundColor` (`src/lib/figmaUtils/index.ts`) scans a node's `fills` array back-to-front to find the topmost visible `SOLID` fill — Figma's fills array is ordered back-to-front, so the last visible solid entry is what's actually rendered, not the first.
 
+**Before hand-rolling any new `plugin/code.ts` logic that walks/filters/inspects the scene graph, check whether `@create-figma-plugin/utilities` (already a dependency, already used for `isScannable`) has it first.** It covers a lot of the fiddly Figma-API surface this plugin otherwise reimplements by hand — node traversal, visibility/lock checks, colour conversions, and more. Cheaper to depend on a maintained helper than to add another bespoke node-walking function to this codebase.
+
 All detected issues are shaped as `IssueX` (`src/lib/types.ts`), tagged with an `IssueType` and `Severity`, and carry a `NodeDataType` payload (the node id, name, and whatever fields are relevant to that issue type) used later for navigation and display.
 
 ### AI alt-text generation (separate network path)

--- a/plugin/code.ts
+++ b/plugin/code.ts
@@ -1,6 +1,11 @@
 /// <reference types="@figma/plugin-typings" />
 
-import { isLocked, isVisible } from "@create-figma-plugin/utilities";
+import {
+  convertHexColorToRgbColor,
+  isLocked,
+  isVisible,
+} from "@create-figma-plugin/utilities";
+import { RGBColor } from "wcag-contrast";
 
 import { MESSAGE_TYPES, MIN_FONT_SIZE } from "@/lib/constants";
 import {
@@ -11,10 +16,12 @@ import {
   isTouchTargetTooClose,
   isTouchTargetTooSmall,
   postMessageToUI,
+  replaceTopmostVisibleSolidFillColor,
 } from "@/lib/figmaUtils";
 import generateAltTextForLayer from "@/lib/helpers/generateAltTextForLayer";
 import { IssueX } from "@/lib/types";
 import {
+  figmaRGBtoHex,
   getIsQuickCheckModeActive,
   setIsQuickCheckModeActive,
 } from "@/lib/utils";
@@ -39,6 +46,10 @@ figma.ui.onmessage = async (message) => {
 
       case MESSAGE_TYPES.UPDATE_FONT_SIZE:
         await handleUpdateFontSize(message);
+        break;
+
+      case MESSAGE_TYPES.UPDATE_FILL_COLOR:
+        await handleUpdateFillColor(message);
         break;
 
       case MESSAGE_TYPES.NAVIGATE:
@@ -142,6 +153,38 @@ async function handleUpdateFontSize(message: { id: string; fontSize: number }) {
   } else {
     console.warn(`Failed to update font size for node ${message.id}`);
   }
+}
+
+async function handleUpdateFillColor(message: {
+  nodeId: string;
+  color: RGBColor;
+}) {
+  const node = await figma.getNodeByIdAsync(message.nodeId);
+  if (!node || !("fills" in node) || !Array.isArray(node.fills)) {
+    console.warn(`Failed to update fill color for node ${message.nodeId}`);
+    return;
+  }
+
+  const figmaColor = convertHexColorToRgbColor(
+    figmaRGBtoHex(message.color).slice(1),
+  );
+  if (!figmaColor) {
+    console.warn(
+      `Failed to convert suggested color for node ${message.nodeId}`,
+    );
+    return;
+  }
+
+  const updatedFills = replaceTopmostVisibleSolidFillColor(
+    node.fills as Paint[],
+    figmaColor,
+  );
+  if (!updatedFills) {
+    console.warn(`No visible solid fill found on node ${message.nodeId}`);
+    return;
+  }
+
+  node.fills = updatedFills;
 }
 
 function handleNotify(message: { message: string }) {

--- a/src/components/organisms/AccessibilityValidator/index.tsx
+++ b/src/components/organisms/AccessibilityValidator/index.tsx
@@ -56,7 +56,7 @@ export default function AccessibilityValidator() {
             <li
               key={issue.id}
               title={`Find ${label} issues`}
-              className="group flex items-center justify-between rounded-xl bg-dark-shade text-grey transition-all duration-200 ease-in-out hover:cursor-pointer hover:ring-1 hover:ring-accent"
+              className="group flex items-center justify-between rounded-xl border border-rose-50/10 bg-dark-shade text-grey transition-all duration-200 ease-in-out hover:cursor-pointer hover:ring-1 hover:ring-accent"
             >
               <button
                 type="button"

--- a/src/components/organisms/ContrastFixSuggester/index.test.tsx
+++ b/src/components/organisms/ContrastFixSuggester/index.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ColorFixSuggestion } from "@/lib/colorFix";
+import ContrastFixSuggester from "./index";
+
+const darkerSuggestion: ColorFixSuggestion = {
+  color: [10, 10, 10],
+  ratio: 5.2,
+  adjustment: "darker",
+};
+
+const lighterSuggestion: ColorFixSuggestion = {
+  color: [240, 240, 240],
+  ratio: 6.1,
+  adjustment: "lighter",
+};
+
+describe("ContrastFixSuggester", () => {
+  it("shows a no-suggestion message for the current target level when neither suggestion exists", () => {
+    render(
+      <ContrastFixSuggester
+        targetLevel="AAA"
+        onTargetLevelChange={vi.fn()}
+        foregroundSuggestion={null}
+        backgroundSuggestion={null}
+        onSelectSwatchNode={vi.fn()}
+        onApplySuggestion={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("No AAA-compliant suggestion found for this pair."),
+    ).toBeVisible();
+  });
+
+  it("labels a suggestion by its actual adjustment direction, not the swatch direction", () => {
+    render(
+      <ContrastFixSuggester
+        targetLevel="AA"
+        onTargetLevelChange={vi.fn()}
+        foregroundSuggestion={darkerSuggestion}
+        backgroundSuggestion={lighterSuggestion}
+        onSelectSwatchNode={vi.fn()}
+        onApplySuggestion={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Darken text")).toBeVisible();
+    expect(screen.getByText("Lighten background")).toBeVisible();
+    expect(screen.getByText("5.20:1")).toBeVisible();
+    expect(screen.getByText("6.10:1")).toBeVisible();
+  });
+
+  it("calls onSelectSwatchNode with the swatch's direction when a swatch is clicked", async () => {
+    const user = userEvent.setup();
+    const onSelectSwatchNode = vi.fn();
+
+    render(
+      <ContrastFixSuggester
+        targetLevel="AA"
+        onTargetLevelChange={vi.fn()}
+        foregroundSuggestion={darkerSuggestion}
+        backgroundSuggestion={null}
+        onSelectSwatchNode={onSelectSwatchNode}
+        onApplySuggestion={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByTitle("Select the text layer in Figma"));
+
+    expect(onSelectSwatchNode).toHaveBeenCalledWith("foreground");
+  });
+
+  it("calls onApplySuggestion with the direction and suggestion when Apply is clicked", async () => {
+    const user = userEvent.setup();
+    const onApplySuggestion = vi.fn();
+
+    render(
+      <ContrastFixSuggester
+        targetLevel="AA"
+        onTargetLevelChange={vi.fn()}
+        foregroundSuggestion={null}
+        backgroundSuggestion={lighterSuggestion}
+        onSelectSwatchNode={vi.fn()}
+        onApplySuggestion={onApplySuggestion}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    expect(onApplySuggestion).toHaveBeenCalledWith(
+      "background",
+      lighterSuggestion,
+    );
+  });
+
+  it("pluralizes the shared-background note based on the shared count", () => {
+    render(
+      <ContrastFixSuggester
+        targetLevel="AA"
+        onTargetLevelChange={vi.fn()}
+        foregroundSuggestion={null}
+        backgroundSuggestion={lighterSuggestion}
+        backgroundSharedWithCount={1}
+        onSelectSwatchNode={vi.fn()}
+        onApplySuggestion={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Shared with 1 other layer")).toBeVisible();
+  });
+
+  it("calls onTargetLevelChange when a target level radio is selected", async () => {
+    const user = userEvent.setup();
+    const onTargetLevelChange = vi.fn();
+
+    render(
+      <ContrastFixSuggester
+        targetLevel="AA"
+        onTargetLevelChange={onTargetLevelChange}
+        foregroundSuggestion={null}
+        backgroundSuggestion={null}
+        onSelectSwatchNode={vi.fn()}
+        onApplySuggestion={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("radio", { name: "AAA" }));
+
+    expect(onTargetLevelChange).toHaveBeenCalledWith("AAA");
+  });
+});

--- a/src/components/organisms/ContrastFixSuggester/index.tsx
+++ b/src/components/organisms/ContrastFixSuggester/index.tsx
@@ -1,0 +1,174 @@
+import { Button } from "@/components/ui/button";
+import { ColorFixDirection, ColorFixSuggestion } from "@/lib/colorFix";
+import { cn, figmaRGBtoHex, getSeverityStyles } from "@/lib/utils";
+import { Check } from "lucide-react";
+
+export type TargetLevel = "AA" | "AAA";
+
+const TARGET_LEVELS: readonly TargetLevel[] = ["AA", "AAA"] as const;
+
+export type ContrastFixSuggesterProps = {
+  targetLevel: TargetLevel;
+  onTargetLevelChange: (level: TargetLevel) => void;
+  foregroundSuggestion: ColorFixSuggestion | null;
+  backgroundSuggestion: ColorFixSuggestion | null;
+  backgroundSharedWithCount?: number;
+  onSelectSwatchNode: (direction: ColorFixDirection) => void;
+  onApplySuggestion: (
+    direction: ColorFixDirection,
+    suggestion: ColorFixSuggestion,
+  ) => void;
+};
+
+export default function ContrastFixSuggester({
+  targetLevel,
+  onTargetLevelChange,
+  foregroundSuggestion,
+  backgroundSuggestion,
+  backgroundSharedWithCount,
+  onSelectSwatchNode,
+  onApplySuggestion,
+}: ContrastFixSuggesterProps) {
+  return (
+    <div className="grid w-full rounded-xl border border-rose-50/10 bg-dark-shade p-3">
+      <div className="mb-2 flex items-center justify-between gap-4">
+        <h4 className="text-sm font-medium text-grey">Suggested fixes</h4>
+        <div
+          role="radiogroup"
+          aria-label="Target compliance level"
+          className="inline-flex items-center gap-x-1"
+        >
+          {TARGET_LEVELS.map((level) => (
+            <Button
+              key={level}
+              type="button"
+              title={`Target WCAG ${level}`}
+              role="radio"
+              aria-checked={targetLevel === level}
+              variant="ghost"
+              size="sm"
+              className={cn(
+                "h-6 px-2 text-xs",
+                targetLevel === level &&
+                  "bg-dark text-accent ring-1 ring-accent",
+              )}
+              onClick={() => onTargetLevelChange(level)}
+            >
+              {level}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {!foregroundSuggestion && !backgroundSuggestion ? (
+        <p className="text-xs text-grey">
+          No {targetLevel}-compliant suggestion found for this pair.
+        </p>
+      ) : (
+        <div className="divide-y divide-rose-50/5">
+          {foregroundSuggestion && (
+            <div className="py-1.5 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="inline-flex items-center gap-x-2">
+                  <Button
+                    type="button"
+                    variant="nude"
+                    size="icon"
+                    title="Select the text layer in Figma"
+                    className="size-4 shrink-0 rounded border border-white/20 p-0"
+                    style={{
+                      backgroundColor: figmaRGBtoHex(
+                        foregroundSuggestion.color,
+                      ),
+                    }}
+                    onClick={() => onSelectSwatchNode("foreground")}
+                  />
+                  {foregroundSuggestion.adjustment === "darker"
+                    ? "Darken"
+                    : "Lighten"}{" "}
+                  text
+                </span>
+                <span className="inline-flex items-center gap-x-1 font-mono text-green-500">
+                  <Check aria-hidden="true" className="size-4" />
+                  {foregroundSuggestion.ratio.toFixed(2)}:1
+                </span>
+              </div>
+              <div className="mt-1.5 flex justify-end">
+                <Button
+                  type="button"
+                  title={`${
+                    foregroundSuggestion.adjustment === "darker"
+                      ? "Darken"
+                      : "Lighten"
+                  } the text colour`}
+                  size="sm"
+                  variant="default"
+                  className="h-6 px-3 text-xs"
+                  onClick={() =>
+                    onApplySuggestion("foreground", foregroundSuggestion)
+                  }
+                >
+                  Apply
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {backgroundSuggestion && (
+            <div className="py-1.5 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="inline-flex items-center gap-x-2">
+                  <Button
+                    type="button"
+                    variant="nude"
+                    size="icon"
+                    title="Select the background layer in Figma"
+                    className="size-4 shrink-0 rounded border border-white/20 p-0"
+                    style={{
+                      backgroundColor: figmaRGBtoHex(
+                        backgroundSuggestion.color,
+                      ),
+                    }}
+                    onClick={() => onSelectSwatchNode("background")}
+                  />
+                  {backgroundSuggestion.adjustment === "darker"
+                    ? "Darken"
+                    : "Lighten"}{" "}
+                  background
+                </span>
+                <span className="inline-flex items-center gap-x-1 font-mono text-green-500">
+                  <Check aria-hidden="true" className="size-4" />
+                  {backgroundSuggestion.ratio.toFixed(2)}:1
+                </span>
+              </div>
+              {Boolean(backgroundSharedWithCount) && (
+                <p className={cn("mt-1 text-xs", getSeverityStyles("minor"))}>
+                  Shared with {backgroundSharedWithCount} other layer
+                  {backgroundSharedWithCount === 1 ? "" : "s"}
+                </p>
+              )}
+              <div className="mt-1.5 flex justify-end">
+                <Button
+                  type="button"
+                  title={`${
+                    backgroundSuggestion.adjustment === "darker"
+                      ? "Darken"
+                      : "Lighten"
+                  } the background colour`}
+                  size="sm"
+                  variant="default"
+                  className="h-6 px-3 text-xs"
+                  onClick={() =>
+                    onApplySuggestion("background", backgroundSuggestion)
+                  }
+                >
+                  Apply
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/organisms/IssuesNavigator/index.test.tsx
+++ b/src/components/organisms/IssuesNavigator/index.test.tsx
@@ -140,4 +140,319 @@ describe("IssuesNavigator", () => {
     expect(screen.queryByText("WCAG score:")).toBeNull();
     expect(screen.queryByText("Contrast ratio:")).toBeNull();
   });
+
+  describe("Suggested fixes card", () => {
+    function getDisplayedRatio(label: string): number {
+      const text = screen.getByText(new RegExp(`^${label}$`)).parentElement;
+      const match = text?.textContent?.match(/([\d.]+):1/);
+      if (!match) throw new Error(`No ratio found next to "${label}"`);
+      return parseFloat(match[1]);
+    }
+
+    it("does not render for a non-CONTRAST issue", () => {
+      useIssuesStore.setState({
+        selectedType: "TYPOGRAPHY",
+        issues: [typographyIssue],
+      });
+      render(<IssuesNavigator />);
+
+      expect(screen.queryByText("Suggested fixes")).toBeNull();
+    });
+
+    it("does not render when the contrast check isn't failing", () => {
+      useIssuesStore.setState({
+        selectedType: "CONTRAST",
+        issues: [
+          {
+            ...contrastIssue,
+            nodeData: {
+              ...contrastIssue.nodeData,
+              contrastScore: { compliance: "AA", ratio: 5 },
+            },
+          },
+        ],
+      });
+      render(<IssuesNavigator />);
+
+      expect(screen.queryByText("Suggested fixes")).toBeNull();
+    });
+
+    it("suggests darkening text that's the lighter of the two colours", () => {
+      useIssuesStore.setState({
+        selectedType: "CONTRAST",
+        issues: [
+          {
+            ...contrastIssue,
+            nodeData: {
+              ...contrastIssue.nodeData,
+              foregroundColor: [128, 128, 128],
+              backgroundColor: [255, 255, 255],
+            },
+          },
+        ],
+      });
+      render(<IssuesNavigator />);
+
+      expect(screen.getByText("Suggested fixes")).toBeVisible();
+      expect(screen.getByText("Darken text")).toBeVisible();
+      expect(getDisplayedRatio("Darken text")).toBeGreaterThanOrEqual(4.5);
+    });
+
+    it("suggests lightening text that's already the darker of the two colours", () => {
+      useIssuesStore.setState({
+        selectedType: "CONTRAST",
+        issues: [
+          {
+            ...contrastIssue,
+            nodeData: {
+              ...contrastIssue.nodeData,
+              foregroundColor: [60, 60, 60],
+              backgroundColor: [20, 20, 20],
+            },
+          },
+        ],
+      });
+      render(<IssuesNavigator />);
+
+      expect(screen.getByText("Lighten text")).toBeVisible();
+    });
+
+    it("recomputes a stricter ratio when the AAA target is selected", async () => {
+      const user = userEvent.setup();
+      useIssuesStore.setState({
+        selectedType: "CONTRAST",
+        issues: [
+          {
+            ...contrastIssue,
+            nodeData: {
+              ...contrastIssue.nodeData,
+              foregroundColor: [130, 130, 130],
+              backgroundColor: [255, 255, 255],
+            },
+          },
+        ],
+      });
+      render(<IssuesNavigator />);
+
+      expect(getDisplayedRatio("Darken text")).toBeGreaterThanOrEqual(4.5);
+
+      await user.click(screen.getByRole("radio", { name: "AAA" }));
+
+      expect(getDisplayedRatio("Darken text")).toBeGreaterThanOrEqual(7);
+    });
+
+    it("discloses when the suggested background is shared with other layers", () => {
+      useIssuesStore.setState({
+        selectedType: "CONTRAST",
+        issues: [
+          {
+            ...contrastIssue,
+            nodeData: {
+              ...contrastIssue.nodeData,
+              backgroundSharedWithCount: 2,
+            },
+          },
+        ],
+      });
+      render(<IssuesNavigator />);
+
+      expect(screen.getByText("Shared with 2 other layers")).toBeVisible();
+    });
+
+    it("omits the disclosure when the background isn't shared with anything else", () => {
+      useIssuesStore.setState({
+        selectedType: "CONTRAST",
+        issues: [contrastIssue],
+      });
+      render(<IssuesNavigator />);
+
+      expect(screen.queryByText(/Shared with/)).toBeNull();
+    });
+
+    it("shows a fallback message when no suggestion is reachable at the selected level", async () => {
+      const user = userEvent.setup();
+      useIssuesStore.setState({
+        selectedType: "CONTRAST",
+        issues: [
+          {
+            ...contrastIssue,
+            nodeData: {
+              ...contrastIssue.nodeData,
+              foregroundColor: [255, 0, 255],
+              backgroundColor: [128, 128, 128],
+            },
+          },
+        ],
+      });
+      render(<IssuesNavigator />);
+
+      await user.click(screen.getByRole("radio", { name: "AAA" }));
+
+      expect(
+        screen.getByText("No AAA-compliant suggestion found for this pair."),
+      ).toBeVisible();
+    });
+
+    it("applies the foreground suggestion, updates local state, and does not toast", async () => {
+      const user = userEvent.setup();
+      useIssuesStore.setState({
+        selectedType: "CONTRAST",
+        issues: [
+          {
+            ...contrastIssue,
+            nodeData: {
+              ...contrastIssue.nodeData,
+              foregroundColor: [128, 128, 128],
+              backgroundColor: [255, 255, 255],
+              backgroundNodeId: "bg-1",
+              backgroundNodeName: "Card",
+            },
+          },
+        ],
+      });
+      render(<IssuesNavigator />);
+
+      const [applyForeground] = screen.getAllByRole("button", {
+        name: "Apply",
+      });
+      await user.click(applyForeground);
+
+      expect(postMessageToBackend).toHaveBeenCalledWith(
+        MESSAGE_TYPES.UPDATE_FILL_COLOR,
+        { nodeId: "c1", color: expect.any(Array) },
+      );
+      expect(postMessageToBackend).not.toHaveBeenCalledWith(
+        MESSAGE_TYPES.NOTIFY,
+        expect.anything(),
+      );
+
+      const updatedIssue = useIssuesStore
+        .getState()
+        .issues.find((issue) => issue.nodeData.id === "c1");
+      expect(updatedIssue?.nodeData.contrastScore?.compliance).not.toBe("Fail");
+      expect(screen.queryByText("Suggested fixes")).toBeNull();
+    });
+
+    it("applies the background suggestion using the contributing node's id and toasts", async () => {
+      const user = userEvent.setup();
+      useIssuesStore.setState({
+        selectedType: "CONTRAST",
+        issues: [
+          {
+            ...contrastIssue,
+            nodeData: {
+              ...contrastIssue.nodeData,
+              foregroundColor: [128, 128, 128],
+              backgroundColor: [255, 255, 255],
+              backgroundNodeId: "bg-1",
+              backgroundNodeName: "Card",
+            },
+          },
+        ],
+      });
+      render(<IssuesNavigator />);
+
+      const [, applyBackground] = screen.getAllByRole("button", {
+        name: "Apply",
+      });
+      await user.click(applyBackground);
+
+      expect(postMessageToBackend).toHaveBeenCalledWith(
+        MESSAGE_TYPES.UPDATE_FILL_COLOR,
+        { nodeId: "bg-1", color: expect.any(Array) },
+      );
+      expect(postMessageToBackend).toHaveBeenCalledWith(MESSAGE_TYPES.NOTIFY, {
+        message: 'Updated background fill on "Card"',
+      });
+    });
+
+    it("navigates to the text node when the foreground swatch is tapped", async () => {
+      const user = userEvent.setup();
+      useIssuesStore.setState({
+        selectedType: "CONTRAST",
+        issues: [
+          {
+            ...contrastIssue,
+            nodeData: {
+              ...contrastIssue.nodeData,
+              foregroundColor: [128, 128, 128],
+              backgroundColor: [255, 255, 255],
+              backgroundNodeId: "bg-1",
+              backgroundNodeName: "Card",
+            },
+          },
+        ],
+      });
+      render(<IssuesNavigator />);
+
+      await user.click(
+        screen.getByRole("button", { name: "Select the text layer in Figma" }),
+      );
+
+      expect(postMessageToBackend).toHaveBeenCalledWith(
+        MESSAGE_TYPES.NAVIGATE,
+        { id: "c1" },
+      );
+    });
+
+    it("navigates to the contributing node when the background swatch is tapped", async () => {
+      const user = userEvent.setup();
+      useIssuesStore.setState({
+        selectedType: "CONTRAST",
+        issues: [
+          {
+            ...contrastIssue,
+            nodeData: {
+              ...contrastIssue.nodeData,
+              foregroundColor: [128, 128, 128],
+              backgroundColor: [255, 255, 255],
+              backgroundNodeId: "bg-1",
+              backgroundNodeName: "Card",
+            },
+          },
+        ],
+      });
+      render(<IssuesNavigator />);
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Select the background layer in Figma",
+        }),
+      );
+
+      expect(postMessageToBackend).toHaveBeenCalledWith(
+        MESSAGE_TYPES.NAVIGATE,
+        { id: "bg-1" },
+      );
+    });
+
+    it("does not navigate for the background swatch when no contributing node was detected", async () => {
+      const user = userEvent.setup();
+      useIssuesStore.setState({
+        selectedType: "CONTRAST",
+        issues: [
+          {
+            ...contrastIssue,
+            nodeData: {
+              ...contrastIssue.nodeData,
+              foregroundColor: [128, 128, 128],
+              backgroundColor: [255, 255, 255],
+            },
+          },
+        ],
+      });
+      render(<IssuesNavigator />);
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Select the background layer in Figma",
+        }),
+      );
+
+      expect(postMessageToBackend).not.toHaveBeenCalledWith(
+        MESSAGE_TYPES.NAVIGATE,
+        expect.anything(),
+      );
+    });
+  });
 });

--- a/src/components/organisms/IssuesNavigator/index.tsx
+++ b/src/components/organisms/IssuesNavigator/index.tsx
@@ -1,12 +1,26 @@
 import IssueDetailRow from "@/components/organisms/IssueDetailRow";
 import IssuesWrapper from "@/components/organisms/IssuesWrapper";
+import { Button } from "@/components/ui/button";
 import Input from "@/components/ui/input";
+import {
+  ColorFixDirection,
+  ColorFixSuggestion,
+  suggestAccessibleColor,
+} from "@/lib/colorFix";
 import { MESSAGE_TYPES, MIN_FONT_SIZE } from "@/lib/constants";
 import { postMessageToBackend } from "@/lib/figmaUtils";
 import { IssueX } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
-import { cn, figmaRGBtoHex, getSeverityStyles } from "@/lib/utils";
+import {
+  cn,
+  figmaRGBtoHex,
+  getContrastCompliance,
+  getSeverityStyles,
+} from "@/lib/utils";
 import { CaseSensitive, Check, OctagonAlert, Palette, X } from "lucide-react";
+import { useState } from "react";
+
+const TARGET_LEVELS = ["AA", "AAA"] as const;
 
 export default function IssuesNavigator() {
   const {
@@ -17,6 +31,7 @@ export default function IssuesNavigator() {
     getIssueGroupList,
     setSingleIssue,
   } = useIssuesStore();
+  const [targetLevel, setTargetLevel] = useState<"AA" | "AAA">("AA");
 
   const issueGroupList: IssueX[] = getIssueGroupList();
   const currentIssue: IssueX = issueGroupList[currentIndex] ?? {};
@@ -62,228 +77,482 @@ export default function IssuesNavigator() {
       id,
       foregroundColor,
       backgroundColor,
+      backgroundNodeId,
+      backgroundNodeName,
+      backgroundSharedWithCount,
+      isBold,
     } = issue.nodeData ?? {};
     const getFontSize = () => fontSize ?? singleIssue?.nodeData?.fontSize ?? 0;
     const fontSizeIsValid = getFontSize() >= MIN_FONT_SIZE;
 
-    return (
-      <div className="relative flex w-full flex-col space-y-1 divide-y divide-rose-50/5 rounded-xl bg-dark-shade p-4 font-medium">
-        <IssueDetailRow
-          icon={<CaseSensitive aria-hidden="true" className="mr-3 size-5" />}
-          label="Text:"
-          value={
-            <span
-              title={characters}
-              className="line-clamp-1 w-full max-w-[10.938rem] text-right font-mono"
-            >
-              {characters}
-            </span>
-          }
-        />
+    const isContrastFail =
+      type === "CONTRAST" && contrastScore?.compliance === "Fail";
+    const foregroundSuggestion =
+      isContrastFail && foregroundColor && backgroundColor
+        ? suggestAccessibleColor(
+            foregroundColor,
+            backgroundColor,
+            getFontSize(),
+            Boolean(isBold),
+            targetLevel,
+            "foreground",
+          )
+        : null;
+    const backgroundSuggestion =
+      isContrastFail && foregroundColor && backgroundColor
+        ? suggestAccessibleColor(
+            foregroundColor,
+            backgroundColor,
+            getFontSize(),
+            Boolean(isBold),
+            targetLevel,
+            "background",
+          )
+        : null;
 
-        <IssueDetailRow
-          icon={
-            fontSizeIsValid ? (
-              <Check
-                aria-hidden="true"
-                className="mr-3 size-5 rounded-full bg-green-500 p-1 text-dark-shade"
-              />
-            ) : (
-              <X
-                aria-hidden="true"
+    const getTargetNodeId = (
+      direction: ColorFixDirection,
+    ): string | undefined => {
+      const textNodeId = singleIssue?.nodeData.id || id || "";
+      return direction === "foreground" ? textNodeId : backgroundNodeId;
+    };
+
+    const handleSelectSwatchNode = (direction: ColorFixDirection) => {
+      const targetNodeId = getTargetNodeId(direction);
+      if (!targetNodeId) return;
+
+      postMessageToBackend(MESSAGE_TYPES.NAVIGATE, { id: targetNodeId });
+    };
+
+    const handleApplyColorSuggestion = (
+      direction: ColorFixDirection,
+      suggestion: ColorFixSuggestion,
+    ) => {
+      const targetNodeId = getTargetNodeId(direction);
+      if (!targetNodeId) return;
+
+      const updatedForeground =
+        direction === "foreground" ? suggestion.color : foregroundColor;
+      const updatedBackground =
+        direction === "background" ? suggestion.color : backgroundColor;
+      const newContrastScore =
+        updatedForeground && updatedBackground
+          ? getContrastCompliance(
+              updatedForeground,
+              updatedBackground,
+              getFontSize(),
+              Boolean(isBold),
+            )
+          : contrastScore;
+
+      const nodeDataUpdates =
+        direction === "foreground"
+          ? {
+              foregroundColor: suggestion.color,
+              contrastScore: newContrastScore,
+            }
+          : {
+              backgroundColor: suggestion.color,
+              contrastScore: newContrastScore,
+            };
+
+      if (singleIssue) {
+        setSingleIssue({
+          ...singleIssue,
+          nodeData: { ...singleIssue.nodeData, ...nodeDataUpdates },
+        });
+      } else {
+        updateIssue(id || "", {
+          nodeData: { ...currentIssue.nodeData, ...nodeDataUpdates },
+        });
+      }
+
+      postMessageToBackend(MESSAGE_TYPES.UPDATE_FILL_COLOR, {
+        nodeId: targetNodeId,
+        color: suggestion.color,
+      });
+
+      if (direction === "background" && backgroundNodeName) {
+        postMessageToBackend(MESSAGE_TYPES.NOTIFY, {
+          message: `Updated background fill on "${backgroundNodeName}"`,
+        });
+      }
+    };
+
+    return (
+      <>
+        <div className="relative flex w-full flex-col space-y-1 divide-y divide-rose-50/5 rounded-xl bg-dark-shade p-4 font-medium">
+          <IssueDetailRow
+            icon={<CaseSensitive aria-hidden="true" className="mr-3 size-5" />}
+            label="Text:"
+            value={
+              <span
+                title={characters}
+                className="line-clamp-1 w-full max-w-[10.938rem] text-right font-mono"
+              >
+                {characters}
+              </span>
+            }
+          />
+
+          <IssueDetailRow
+            icon={
+              fontSizeIsValid ? (
+                <Check
+                  aria-hidden="true"
+                  className="mr-3 size-5 rounded-full bg-green-500 p-1 text-dark-shade"
+                />
+              ) : (
+                <X
+                  aria-hidden="true"
+                  className={cn(
+                    "mr-3 size-5 rounded-full p-1",
+                    (!fontSizeIsValid && severity === "major") ||
+                      (!fontSizeIsValid && severity === "critical")
+                      ? "bg-orange-500 text-dark-shade"
+                      : "bg-rose-600 text-dark-shade",
+                  )}
+                />
+              )
+            }
+            label={
+              <span
                 className={cn(
-                  "mr-3 size-5 rounded-full p-1",
-                  (!fontSizeIsValid && severity === "major") ||
-                    (!fontSizeIsValid && severity === "critical")
-                    ? "bg-orange-500 text-dark-shade"
-                    : "bg-rose-600 text-dark-shade",
+                  "text-sm",
+                  !fontSizeIsValid &&
+                    type === "CONTRAST" &&
+                    getSeverityStyles("major", { isBold: true }),
+                  !fontSizeIsValid &&
+                    type === "TYPOGRAPHY" &&
+                    getSeverityStyles(severity, { isBold: true }),
+                )}
+              >
+                Font size:
+              </span>
+            }
+            value={
+              <Input
+                type="number"
+                min={0}
+                value={fontSize || ""}
+                onInput={(e) =>
+                  handleFontSizeChange(
+                    singleIssue?.nodeData.id || id || "",
+                    e.currentTarget.value,
+                    Boolean(singleIssue),
+                  )
+                }
+                className={cn(
+                  "ml-2.5 h-full !w-fit max-w-[4.4rem] bg-transparent font-black",
+                  {
+                    "text-orange-500":
+                      (!fontSizeIsValid && severity === "major") ||
+                      (!fontSizeIsValid && severity === "critical"),
+                  },
                 )}
               />
-            )
-          }
-          label={
-            <span
-              className={cn(
-                "text-sm",
-                !fontSizeIsValid &&
-                  type === "CONTRAST" &&
-                  getSeverityStyles("major", { isBold: true }),
-                !fontSizeIsValid &&
-                  type === "TYPOGRAPHY" &&
-                  getSeverityStyles(severity, { isBold: true }),
-              )}
-            >
-              Font size:
-            </span>
-          }
-          value={
-            <Input
-              type="number"
-              min={0}
-              value={fontSize || ""}
-              onInput={(e) =>
-                handleFontSizeChange(
-                  singleIssue?.nodeData.id || id || "",
-                  e.currentTarget.value,
-                  Boolean(singleIssue),
-                )
-              }
-              className={cn(
-                "ml-2.5 h-full !w-fit max-w-[4.4rem] bg-transparent font-black",
-                {
-                  "text-orange-500":
-                    (!fontSizeIsValid && severity === "major") ||
-                    (!fontSizeIsValid && severity === "critical"),
-                },
-              )}
-            />
-          }
-          tooltip={
-            !fontSizeIsValid &&
-            `The text size is below recommended standards for readability. Consider increasing it to at least ${MIN_FONT_SIZE}px to ensure better legibility.`
-          }
-        />
+            }
+            tooltip={
+              !fontSizeIsValid &&
+              `The text size is below recommended standards for readability. Consider increasing it to at least ${MIN_FONT_SIZE}px to ensure better legibility.`
+            }
+          />
 
-        {type === "CONTRAST" && (
-          <>
-            {foregroundColor && (
+          {type === "CONTRAST" && (
+            <>
+              {foregroundColor && (
+                <IssueDetailRow
+                  icon={<Palette aria-hidden="true" className="mr-3 size-5" />}
+                  label={<span className="text-sm">Text colour:</span>}
+                  value={
+                    <span className="ml-2.5 inline-flex items-center gap-x-2 font-mono text-sm">
+                      <span
+                        className="size-4 shrink-0 rounded border border-white/20"
+                        style={{
+                          backgroundColor: figmaRGBtoHex(foregroundColor),
+                        }}
+                      />
+                      {figmaRGBtoHex(foregroundColor)}
+                    </span>
+                  }
+                />
+              )}
+
+              {backgroundColor && (
+                <IssueDetailRow
+                  icon={<Palette aria-hidden="true" className="mr-3 size-5" />}
+                  label={<span className="text-sm">Background colour:</span>}
+                  value={
+                    <span className="ml-2.5 inline-flex items-center gap-x-2 font-mono text-sm">
+                      <span
+                        className="size-4 shrink-0 rounded border border-white/20"
+                        style={{
+                          backgroundColor: figmaRGBtoHex(backgroundColor),
+                        }}
+                      />
+                      {figmaRGBtoHex(backgroundColor)}
+                    </span>
+                  }
+                />
+              )}
+
               <IssueDetailRow
-                icon={<Palette aria-hidden="true" className="mr-3 size-5" />}
-                label={<span className="text-sm">Text colour:</span>}
-                value={
-                  <span className="ml-2.5 inline-flex items-center gap-x-2 font-mono text-sm">
-                    <span
-                      className="size-4 shrink-0 rounded border border-white/20"
-                      style={{
-                        backgroundColor: figmaRGBtoHex(foregroundColor),
-                      }}
+                icon={
+                  contrastScore?.compliance === "Fail" ? (
+                    <X
+                      aria-hidden="true"
+                      className={cn(
+                        getSeverityStyles(severity, { isIcon: true }),
+                      )}
                     />
-                    {figmaRGBtoHex(foregroundColor)}
+                  ) : (
+                    <Check
+                      aria-hidden="true"
+                      className="mr-3 size-5 rounded-full bg-green-500 p-1 text-dark-shade"
+                    />
+                  )
+                }
+                label={
+                  <span
+                    className={cn(
+                      "text-sm",
+                      contrastScore?.compliance === "Fail" &&
+                        getSeverityStyles(severity, { isBold: true }),
+                    )}
+                  >
+                    WCAG score:
+                  </span>
+                }
+                value={
+                  <span
+                    className={cn(
+                      "font-bold ml-2.5 text-base",
+                      contrastScore?.compliance === "Fail" &&
+                        getSeverityStyles(severity, { isBold: true }),
+                    )}
+                  >
+                    {contrastScore?.compliance}
+                  </span>
+                }
+                tooltip={
+                  contrastScore?.compliance === "Fail" &&
+                  "The color contrast between the text and the background on this screen is insufficient to meet the enhanced contrast requirements. In some edge cases, the test may fail when the background element is a “GROUP,” “COMPONENT,” or “INSTANCE. Other times, a background couldn't be detected."
+                }
+              />
+
+              <IssueDetailRow
+                icon={
+                  contrastScore?.compliance === "Fail" ? (
+                    <X
+                      aria-hidden="true"
+                      className={cn(
+                        getSeverityStyles(severity, { isIcon: true }),
+                      )}
+                    />
+                  ) : (
+                    <Check
+                      aria-hidden="true"
+                      className="mr-3 size-5 rounded-full bg-green-500 p-1 text-dark-shade"
+                    />
+                  )
+                }
+                label={
+                  <span
+                    className={cn(
+                      "text-sm",
+                      contrastScore?.compliance === "Fail" &&
+                        getSeverityStyles(severity, { isBold: true }),
+                    )}
+                  >
+                    Contrast ratio:
+                  </span>
+                }
+                value={
+                  <span
+                    className={cn(
+                      "font-bold ml-2.5 text-base",
+                      contrastScore?.compliance === "Fail" &&
+                        getSeverityStyles(severity, { isBold: true }),
+                    )}
+                  >
+                    {contrastScore?.ratio.toFixed(2)} : 1
                   </span>
                 }
               />
-            )}
+            </>
+          )}
 
-            {backgroundColor && (
-              <IssueDetailRow
-                icon={<Palette aria-hidden="true" className="mr-3 size-5" />}
-                label={<span className="text-sm">Background colour:</span>}
-                value={
-                  <span className="ml-2.5 inline-flex items-center gap-x-2 font-mono text-sm">
-                    <span
-                      className="size-4 shrink-0 rounded border border-white/20"
-                      style={{
-                        backgroundColor: figmaRGBtoHex(backgroundColor),
-                      }}
-                    />
-                    {figmaRGBtoHex(backgroundColor)}
-                  </span>
-                }
-              />
-            )}
+          <IssueDetailRow
+            label="Severity:"
+            value={
+              <span
+                className={cn("font-bold capitalize text-base", {
+                  "text-rose-600": severity === "critical",
+                  "text-orange-500": severity === "major",
+                  "text-amber-500": severity === "minor",
+                })}
+              >
+                {severity}
+              </span>
+            }
+            icon={<OctagonAlert aria-hidden="true" className="mr-3 size-5" />}
+          />
+        </div>
 
-            <IssueDetailRow
-              icon={
-                contrastScore?.compliance === "Fail" ? (
-                  <X
-                    aria-hidden="true"
+        {isContrastFail && (
+          <div className="grid w-full rounded-xl border border-rose-50/10 bg-dark-shade p-3">
+            <div className="mb-2 flex items-center justify-between gap-4">
+              <h4 className="text-sm font-medium text-grey">Suggested fixes</h4>
+              <div
+                role="radiogroup"
+                aria-label="Target compliance level"
+                className="inline-flex items-center gap-x-1"
+              >
+                {TARGET_LEVELS.map((level) => (
+                  <Button
+                    key={level}
+                    type="button"
+                    title={`Target WCAG ${level}`}
+                    role="radio"
+                    aria-checked={targetLevel === level}
+                    variant="ghost"
+                    size="sm"
                     className={cn(
-                      getSeverityStyles(severity, { isIcon: true }),
+                      "h-6 px-2 text-xs",
+                      targetLevel === level &&
+                        "bg-dark text-accent ring-1 ring-accent",
                     )}
-                  />
-                ) : (
-                  <Check
-                    aria-hidden="true"
-                    className="mr-3 size-5 rounded-full bg-green-500 p-1 text-dark-shade"
-                  />
-                )
-              }
-              label={
-                <span
-                  className={cn(
-                    "text-sm",
-                    contrastScore?.compliance === "Fail" &&
-                      getSeverityStyles(severity, { isBold: true }),
-                  )}
-                >
-                  WCAG score:
-                </span>
-              }
-              value={
-                <span
-                  className={cn(
-                    "font-bold ml-2.5 text-base",
-                    contrastScore?.compliance === "Fail" &&
-                      getSeverityStyles(severity, { isBold: true }),
-                  )}
-                >
-                  {contrastScore?.compliance}
-                </span>
-              }
-              tooltip={
-                contrastScore?.compliance === "Fail" &&
-                "The color contrast between the text and the background on this screen is insufficient to meet the enhanced contrast requirements. In some edge cases, the test may fail when the background element is a “GROUP,” “COMPONENT,” or “INSTANCE. Other times, a background couldn't be detected."
-              }
-            />
+                    onClick={() => setTargetLevel(level)}
+                  >
+                    {level}
+                  </Button>
+                ))}
+              </div>
+            </div>
 
-            <IssueDetailRow
-              icon={
-                contrastScore?.compliance === "Fail" ? (
-                  <X
-                    aria-hidden="true"
-                    className={cn(
-                      getSeverityStyles(severity, { isIcon: true }),
+            {!foregroundSuggestion && !backgroundSuggestion ? (
+              <p className="text-xs text-grey">
+                No {targetLevel}-compliant suggestion found for this pair.
+              </p>
+            ) : (
+              <div className="divide-y divide-rose-50/5">
+                {foregroundSuggestion && (
+                  <div className="py-1.5 text-sm">
+                    <div className="flex items-center justify-between">
+                      <span className="inline-flex items-center gap-x-2">
+                        <Button
+                          type="button"
+                          variant="nude"
+                          size="icon"
+                          title="Select the text layer in Figma"
+                          className="size-4 shrink-0 rounded border border-white/20 p-0"
+                          style={{
+                            backgroundColor: figmaRGBtoHex(
+                              foregroundSuggestion.color,
+                            ),
+                          }}
+                          onClick={() => handleSelectSwatchNode("foreground")}
+                        />
+                        {foregroundSuggestion.adjustment === "darker"
+                          ? "Darken"
+                          : "Lighten"}{" "}
+                        text
+                      </span>
+                      <span className="inline-flex items-center gap-x-1 font-mono text-green-500">
+                        <Check aria-hidden="true" className="size-4" />
+                        {foregroundSuggestion.ratio.toFixed(2)}:1
+                      </span>
+                    </div>
+                    <div className="mt-1.5 flex justify-end">
+                      <Button
+                        type="button"
+                        title={`${
+                          foregroundSuggestion.adjustment === "darker"
+                            ? "Darken"
+                            : "Lighten"
+                        } the text colour`}
+                        size="sm"
+                        variant="default"
+                        className="h-6 px-3 text-xs"
+                        onClick={() =>
+                          handleApplyColorSuggestion(
+                            "foreground",
+                            foregroundSuggestion,
+                          )
+                        }
+                      >
+                        Apply
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                {backgroundSuggestion && (
+                  <div className="py-1.5 text-sm">
+                    <div className="flex items-center justify-between">
+                      <span className="inline-flex items-center gap-x-2">
+                        <Button
+                          type="button"
+                          variant="nude"
+                          size="icon"
+                          title="Select the background layer in Figma"
+                          className="size-4 shrink-0 rounded border border-white/20 p-0"
+                          style={{
+                            backgroundColor: figmaRGBtoHex(
+                              backgroundSuggestion.color,
+                            ),
+                          }}
+                          onClick={() => handleSelectSwatchNode("background")}
+                        />
+                        {backgroundSuggestion.adjustment === "darker"
+                          ? "Darken"
+                          : "Lighten"}{" "}
+                        background
+                      </span>
+                      <span className="inline-flex items-center gap-x-1 font-mono text-green-500">
+                        <Check aria-hidden="true" className="size-4" />
+                        {backgroundSuggestion.ratio.toFixed(2)}:1
+                      </span>
+                    </div>
+                    {Boolean(backgroundSharedWithCount) && (
+                      <p
+                        className={cn(
+                          "mt-1 text-xs",
+                          getSeverityStyles("minor"),
+                        )}
+                      >
+                        Shared with {backgroundSharedWithCount} other layer
+                        {backgroundSharedWithCount === 1 ? "" : "s"}
+                      </p>
                     )}
-                  />
-                ) : (
-                  <Check
-                    aria-hidden="true"
-                    className="mr-3 size-5 rounded-full bg-green-500 p-1 text-dark-shade"
-                  />
-                )
-              }
-              label={
-                <span
-                  className={cn(
-                    "text-sm",
-                    contrastScore?.compliance === "Fail" &&
-                      getSeverityStyles(severity, { isBold: true }),
-                  )}
-                >
-                  Contrast ratio:
-                </span>
-              }
-              value={
-                <span
-                  className={cn(
-                    "font-bold ml-2.5 text-base",
-                    contrastScore?.compliance === "Fail" &&
-                      getSeverityStyles(severity, { isBold: true }),
-                  )}
-                >
-                  {contrastScore?.ratio.toFixed(2)} : 1
-                </span>
-              }
-            />
-          </>
+                    <div className="mt-1.5 flex justify-end">
+                      <Button
+                        type="button"
+                        title={`${
+                          backgroundSuggestion.adjustment === "darker"
+                            ? "Darken"
+                            : "Lighten"
+                        } the background colour`}
+                        size="sm"
+                        variant="default"
+                        className="h-6 px-3 text-xs"
+                        onClick={() =>
+                          handleApplyColorSuggestion(
+                            "background",
+                            backgroundSuggestion,
+                          )
+                        }
+                      >
+                        Apply
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
         )}
-
-        <IssueDetailRow
-          label="Severity:"
-          value={
-            <span
-              className={cn("font-bold capitalize text-base", {
-                "text-rose-600": severity === "critical",
-                "text-orange-500": severity === "major",
-                "text-amber-500": severity === "minor",
-              })}
-            >
-              {severity}
-            </span>
-          }
-          icon={<OctagonAlert aria-hidden="true" className="mr-3 size-5" />}
-        />
-      </div>
+      </>
     );
   };
 

--- a/src/components/organisms/IssuesNavigator/index.tsx
+++ b/src/components/organisms/IssuesNavigator/index.tsx
@@ -181,7 +181,7 @@ export default function IssuesNavigator() {
 
     return (
       <>
-        <div className="relative flex w-full flex-col space-y-1 divide-y divide-rose-50/5 rounded-xl bg-dark-shade p-4 font-medium">
+        <div className="relative flex w-full flex-col space-y-1 divide-y divide-rose-50/5 rounded-xl border border-rose-50/10 bg-dark-shade p-4 font-medium">
           <IssueDetailRow
             icon={<CaseSensitive aria-hidden="true" className="mr-3 size-5" />}
             label="Text:"

--- a/src/components/organisms/IssuesNavigator/index.tsx
+++ b/src/components/organisms/IssuesNavigator/index.tsx
@@ -1,6 +1,8 @@
+import ContrastFixSuggester, {
+  TargetLevel,
+} from "@/components/organisms/ContrastFixSuggester";
 import IssueDetailRow from "@/components/organisms/IssueDetailRow";
 import IssuesWrapper from "@/components/organisms/IssuesWrapper";
-import { Button } from "@/components/ui/button";
 import Input from "@/components/ui/input";
 import {
   ColorFixDirection,
@@ -20,8 +22,6 @@ import {
 import { CaseSensitive, Check, OctagonAlert, Palette, X } from "lucide-react";
 import { useState } from "react";
 
-const TARGET_LEVELS = ["AA", "AAA"] as const;
-
 export default function IssuesNavigator() {
   const {
     currentIndex,
@@ -31,7 +31,7 @@ export default function IssuesNavigator() {
     getIssueGroupList,
     setSingleIssue,
   } = useIssuesStore();
-  const [targetLevel, setTargetLevel] = useState<"AA" | "AAA">("AA");
+  const [targetLevel, setTargetLevel] = useState<TargetLevel>("AA");
 
   const issueGroupList: IssueX[] = getIssueGroupList();
   const currentIssue: IssueX = issueGroupList[currentIndex] ?? {};
@@ -400,157 +400,15 @@ export default function IssuesNavigator() {
         </div>
 
         {isContrastFail && (
-          <div className="grid w-full rounded-xl border border-rose-50/10 bg-dark-shade p-3">
-            <div className="mb-2 flex items-center justify-between gap-4">
-              <h4 className="text-sm font-medium text-grey">Suggested fixes</h4>
-              <div
-                role="radiogroup"
-                aria-label="Target compliance level"
-                className="inline-flex items-center gap-x-1"
-              >
-                {TARGET_LEVELS.map((level) => (
-                  <Button
-                    key={level}
-                    type="button"
-                    title={`Target WCAG ${level}`}
-                    role="radio"
-                    aria-checked={targetLevel === level}
-                    variant="ghost"
-                    size="sm"
-                    className={cn(
-                      "h-6 px-2 text-xs",
-                      targetLevel === level &&
-                        "bg-dark text-accent ring-1 ring-accent",
-                    )}
-                    onClick={() => setTargetLevel(level)}
-                  >
-                    {level}
-                  </Button>
-                ))}
-              </div>
-            </div>
-
-            {!foregroundSuggestion && !backgroundSuggestion ? (
-              <p className="text-xs text-grey">
-                No {targetLevel}-compliant suggestion found for this pair.
-              </p>
-            ) : (
-              <div className="divide-y divide-rose-50/5">
-                {foregroundSuggestion && (
-                  <div className="py-1.5 text-sm">
-                    <div className="flex items-center justify-between">
-                      <span className="inline-flex items-center gap-x-2">
-                        <Button
-                          type="button"
-                          variant="nude"
-                          size="icon"
-                          title="Select the text layer in Figma"
-                          className="size-4 shrink-0 rounded border border-white/20 p-0"
-                          style={{
-                            backgroundColor: figmaRGBtoHex(
-                              foregroundSuggestion.color,
-                            ),
-                          }}
-                          onClick={() => handleSelectSwatchNode("foreground")}
-                        />
-                        {foregroundSuggestion.adjustment === "darker"
-                          ? "Darken"
-                          : "Lighten"}{" "}
-                        text
-                      </span>
-                      <span className="inline-flex items-center gap-x-1 font-mono text-green-500">
-                        <Check aria-hidden="true" className="size-4" />
-                        {foregroundSuggestion.ratio.toFixed(2)}:1
-                      </span>
-                    </div>
-                    <div className="mt-1.5 flex justify-end">
-                      <Button
-                        type="button"
-                        title={`${
-                          foregroundSuggestion.adjustment === "darker"
-                            ? "Darken"
-                            : "Lighten"
-                        } the text colour`}
-                        size="sm"
-                        variant="default"
-                        className="h-6 px-3 text-xs"
-                        onClick={() =>
-                          handleApplyColorSuggestion(
-                            "foreground",
-                            foregroundSuggestion,
-                          )
-                        }
-                      >
-                        Apply
-                      </Button>
-                    </div>
-                  </div>
-                )}
-
-                {backgroundSuggestion && (
-                  <div className="py-1.5 text-sm">
-                    <div className="flex items-center justify-between">
-                      <span className="inline-flex items-center gap-x-2">
-                        <Button
-                          type="button"
-                          variant="nude"
-                          size="icon"
-                          title="Select the background layer in Figma"
-                          className="size-4 shrink-0 rounded border border-white/20 p-0"
-                          style={{
-                            backgroundColor: figmaRGBtoHex(
-                              backgroundSuggestion.color,
-                            ),
-                          }}
-                          onClick={() => handleSelectSwatchNode("background")}
-                        />
-                        {backgroundSuggestion.adjustment === "darker"
-                          ? "Darken"
-                          : "Lighten"}{" "}
-                        background
-                      </span>
-                      <span className="inline-flex items-center gap-x-1 font-mono text-green-500">
-                        <Check aria-hidden="true" className="size-4" />
-                        {backgroundSuggestion.ratio.toFixed(2)}:1
-                      </span>
-                    </div>
-                    {Boolean(backgroundSharedWithCount) && (
-                      <p
-                        className={cn(
-                          "mt-1 text-xs",
-                          getSeverityStyles("minor"),
-                        )}
-                      >
-                        Shared with {backgroundSharedWithCount} other layer
-                        {backgroundSharedWithCount === 1 ? "" : "s"}
-                      </p>
-                    )}
-                    <div className="mt-1.5 flex justify-end">
-                      <Button
-                        type="button"
-                        title={`${
-                          backgroundSuggestion.adjustment === "darker"
-                            ? "Darken"
-                            : "Lighten"
-                        } the background colour`}
-                        size="sm"
-                        variant="default"
-                        className="h-6 px-3 text-xs"
-                        onClick={() =>
-                          handleApplyColorSuggestion(
-                            "background",
-                            backgroundSuggestion,
-                          )
-                        }
-                      >
-                        Apply
-                      </Button>
-                    </div>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
+          <ContrastFixSuggester
+            targetLevel={targetLevel}
+            onTargetLevelChange={setTargetLevel}
+            foregroundSuggestion={foregroundSuggestion}
+            backgroundSuggestion={backgroundSuggestion}
+            backgroundSharedWithCount={backgroundSharedWithCount}
+            onSelectSwatchNode={handleSelectSwatchNode}
+            onApplySuggestion={handleApplyColorSuggestion}
+          />
         )}
       </>
     );

--- a/src/components/organisms/IssuesOverviewList/index.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.tsx
@@ -221,7 +221,7 @@ export default function IssuesOverviewList() {
                       <li
                         key={issue.id}
                         title={`View all ${label} issues`}
-                        className="group flex items-center justify-between rounded-xl bg-dark-shade text-grey transition-all duration-200 ease-in-out hover:cursor-pointer hover:ring-1 hover:ring-accent"
+                        className="group flex items-center justify-between rounded-xl border border-rose-50/10 bg-dark-shade text-grey transition-all duration-200 ease-in-out hover:cursor-pointer hover:ring-1 hover:ring-accent"
                       >
                         <button
                           className="flex w-full flex-col gap-y-2 px-4 py-3.5 text-left"

--- a/src/components/organisms/TouchTargetNavigator/index.tsx
+++ b/src/components/organisms/TouchTargetNavigator/index.tsx
@@ -35,7 +35,7 @@ export default function TouchTargetNavigator() {
     const isHeightFail = (height ?? 0) < MIN_TOUCH_TARGET_SIZE;
 
     return (
-      <div className="relative flex w-full flex-col space-y-1 divide-y divide-rose-50/5 rounded-xl bg-dark-shade p-4 font-medium">
+      <div className="relative flex w-full flex-col space-y-1 divide-y divide-rose-50/5 rounded-xl border border-rose-50/10 bg-dark-shade p-4 font-medium">
         <IssueDetailRow
           icon={<Target aria-hidden="true" className="mr-3 size-5" />}
           label="Element:"

--- a/src/components/organisms/ai-assistants/AltTextGenerator/index.tsx
+++ b/src/components/organisms/ai-assistants/AltTextGenerator/index.tsx
@@ -128,7 +128,7 @@ export default function AltTextGenerator({
       tabIndex={0}
       aria-label="Alt Text Generator"
       className={cn(
-        "flex items-center justify-between rounded-xl bg-dark-shade transition-all duration-200 ease-in-out delay-1000",
+        "flex items-center justify-between rounded-xl border border-rose-50/10 bg-dark-shade transition-all duration-200 ease-in-out delay-1000",
         {
           "group text-grey hover:cursor-pointer hover:ring-1 hover:ring-accent":
             !isExpanded,

--- a/src/lib/colorFix/index.test.ts
+++ b/src/lib/colorFix/index.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import { RGBColor } from "wcag-contrast";
+import { getContrastCompliance } from "@/lib/utils";
+import { suggestAccessibleColor } from "./index";
+
+const WHITE: RGBColor = [255, 255, 255];
+const BLACK: RGBColor = [0, 0, 0];
+
+describe("suggestAccessibleColor", () => {
+  it("returns null when the pair is already compliant at the requested level", () => {
+    expect(
+      suggestAccessibleColor(BLACK, WHITE, 16, false, "AA", "foreground"),
+    ).toBeNull();
+  });
+
+  it("darkens text that's the lighter of the two colours", () => {
+    const foreground: RGBColor = [128, 128, 128];
+    const result = suggestAccessibleColor(
+      foreground,
+      WHITE,
+      16,
+      false,
+      "AA",
+      "foreground",
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.adjustment).toBe("darker");
+    expect(result?.ratio).toBeGreaterThanOrEqual(4.5);
+    // Cross-checked against the same production function real detection
+    // uses, not just this module's own ratio field.
+    expect(
+      getContrastCompliance(result!.color, WHITE, 16, false).compliance,
+    ).not.toBe("Fail");
+  });
+
+  it("lightens text that's already the darker of the two colours, rather than darkening it further", () => {
+    // Background is near-black and darker than the failing text - darkening
+    // the text further would move it toward the background, not away.
+    const foreground: RGBColor = [60, 60, 60];
+    const background: RGBColor = [20, 20, 20];
+    const result = suggestAccessibleColor(
+      foreground,
+      background,
+      16,
+      false,
+      "AA",
+      "foreground",
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.adjustment).toBe("lighter");
+    expect(
+      getContrastCompliance(result!.color, background, 16, false).compliance,
+    ).not.toBe("Fail");
+  });
+
+  it("adjusts the background instead of the text when direction is 'background'", () => {
+    const foreground: RGBColor = [80, 80, 80];
+    const background: RGBColor = [100, 100, 100];
+    const result = suggestAccessibleColor(
+      foreground,
+      background,
+      16,
+      false,
+      "AA",
+      "background",
+    );
+
+    expect(result).not.toBeNull();
+    // The suggested colour replaces the background, so re-check against the
+    // unchanged foreground.
+    expect(
+      getContrastCompliance(foreground, result!.color, 16, false).compliance,
+    ).not.toBe("Fail");
+  });
+
+  it("targets a stricter ratio for AAA than for AA", () => {
+    const foreground: RGBColor = [130, 130, 130];
+    const aaResult = suggestAccessibleColor(
+      foreground,
+      WHITE,
+      16,
+      false,
+      "AA",
+      "foreground",
+    );
+    const aaaResult = suggestAccessibleColor(
+      foreground,
+      WHITE,
+      16,
+      false,
+      "AAA",
+      "foreground",
+    );
+
+    expect(aaResult?.ratio).toBeGreaterThanOrEqual(4.5);
+    expect(aaaResult?.ratio).toBeGreaterThanOrEqual(7);
+  });
+
+  it("uses the lower large-text threshold once fontSize crosses 18px", () => {
+    const foreground: RGBColor = [150, 150, 150];
+    // Below 18px: normal text, needs 4.5:1 for AA.
+    const normal = suggestAccessibleColor(
+      foreground,
+      WHITE,
+      17,
+      false,
+      "AA",
+      "foreground",
+    );
+    // At/above 18px: large text, only needs 3:1 for AA - a smaller lightness
+    // change should suffice, so the two results should differ.
+    const large = suggestAccessibleColor(
+      foreground,
+      WHITE,
+      18,
+      false,
+      "AA",
+      "foreground",
+    );
+
+    expect(normal?.ratio).toBeGreaterThanOrEqual(4.5);
+    expect(large?.ratio).toBeGreaterThanOrEqual(3);
+    expect(large?.ratio).toBeLessThan(normal!.ratio);
+  });
+
+  it("treats bold text at 14px as large text, same as the shared getContrastCompliance logic", () => {
+    const foreground: RGBColor = [150, 150, 150];
+    const boldLarge = suggestAccessibleColor(
+      foreground,
+      WHITE,
+      14,
+      true,
+      "AA",
+      "foreground",
+    );
+
+    expect(boldLarge?.ratio).toBeGreaterThanOrEqual(3);
+  });
+
+  it("returns null when no in-gamut candidate exists in either direction", () => {
+    // Mid-gray sits too close to the midpoint of the luminance range for
+    // ANY foreground colour to reach 7:1 against it - not a chroma issue,
+    // a genuine "no reachable candidate" case. Verified: white-vs-this-gray
+    // and black-vs-this-gray both fall short of 7:1.
+    const background: RGBColor = [128, 128, 128];
+    expect(
+      getContrastCompliance(WHITE, background, 16, false).ratio,
+    ).toBeLessThan(7);
+    expect(
+      getContrastCompliance(BLACK, background, 16, false).ratio,
+    ).toBeLessThan(7);
+
+    const result = suggestAccessibleColor(
+      [255, 0, 255],
+      background,
+      16,
+      false,
+      "AAA",
+      "foreground",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("falls back to reducing chroma when a saturated colour can't reach the target at full saturation", () => {
+    // Verified empirically: pure blue against this mid-gray at AAA needs
+    // the chroma-reduction fallback - full-chroma clipping alone isn't
+    // enough to get dark enough.
+    const foreground: RGBColor = [0, 0, 255];
+    const background: RGBColor = [160, 160, 160];
+    const result = suggestAccessibleColor(
+      foreground,
+      background,
+      16,
+      false,
+      "AAA",
+      "foreground",
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.adjustment).toBe("darker");
+    expect(
+      getContrastCompliance(result!.color, background, 16, false).compliance,
+    ).not.toBe("Fail");
+  });
+
+  it("prefers whichever reachable direction requires the smaller lightness change", () => {
+    // Mid-lightness grey on a mid-lightness background: both darkening and
+    // lightening the text can reach AA, so the closer (smaller change)
+    // option should win rather than always defaulting to one pole.
+    const foreground: RGBColor = [128, 128, 128];
+    const background: RGBColor = [128, 128, 128];
+    const result = suggestAccessibleColor(
+      foreground,
+      background,
+      16,
+      false,
+      "AA",
+      "foreground",
+    );
+
+    expect(result).not.toBeNull();
+    expect(
+      getContrastCompliance(result!.color, background, 16, false).compliance,
+    ).not.toBe("Fail");
+  });
+});

--- a/src/lib/colorFix/index.ts
+++ b/src/lib/colorFix/index.ts
@@ -1,0 +1,238 @@
+import { rgb, RGBColor } from "wcag-contrast";
+
+export type ColorFixDirection = "foreground" | "background";
+
+export type ColorFixSuggestion = {
+  color: RGBColor;
+  ratio: number;
+  /**
+   * Which way the suggested colour actually moved from the original. Not
+   * assumed from `direction` - if the foreground happens to already be the
+   * darker of the two colours, darkening it further would move it toward
+   * the background and make contrast worse, not better; lightening it is
+   * the correct fix in that case. The UI label ("Darken text" vs "Lighten
+   * text") should reflect this field, not a hardcoded direction-to-label map.
+   */
+  adjustment: "darker" | "lighter";
+};
+
+const AA_NORMAL_RATIO = 4.5;
+const AA_LARGE_RATIO = 3;
+const AAA_NORMAL_RATIO = 7;
+const AAA_LARGE_RATIO = 4.5;
+
+// Survives rounding when the suggested hex is re-measured after being
+// rendered back to an integer RGB triple.
+const RATIO_BUFFER = 0.05;
+
+// Binary search over CIELAB L* (range 0-100): 20 iterations gives ~0.0001
+// precision, far finer than perceptible - cheap, so no reason to cut corners.
+const MAX_ITERATIONS = 20;
+
+function isLargeText(fontSize: number, isBold: boolean): boolean {
+  return fontSize >= 18 || (isBold && fontSize >= 14);
+}
+
+function getRequiredRatio(targetLevel: "AA" | "AAA", large: boolean): number {
+  if (targetLevel === "AAA") return large ? AAA_LARGE_RATIO : AAA_NORMAL_RATIO;
+  return large ? AA_LARGE_RATIO : AA_NORMAL_RATIO;
+}
+
+// --- sRGB <-> CIELAB (D65 illuminant) ---
+// Plain HSL lightness was considered and rejected: it isn't perceptually
+// uniform, so darkening a saturated blue in HSL can visibly shift toward
+// purple. CIELAB's L* axis holds perceived hue/chroma steady while lightness
+// changes, which is what "here's a good suggestion" actually requires.
+
+const D65 = { x: 0.95047, y: 1.0, z: 1.08883 };
+
+function srgbChannelToLinear(channel: number): number {
+  const value = channel / 255;
+  return value <= 0.04045
+    ? value / 12.92
+    : Math.pow((value + 0.055) / 1.055, 2.4);
+}
+
+function linearChannelToSrgb(channel: number): number {
+  const value =
+    channel <= 0.0031308
+      ? channel * 12.92
+      : 1.055 * Math.pow(channel, 1 / 2.4) - 0.055;
+  return Math.round(Math.min(1, Math.max(0, value)) * 255);
+}
+
+type Xyz = { x: number; y: number; z: number };
+
+function rgbToXyz([r, g, b]: RGBColor): Xyz {
+  const rl = srgbChannelToLinear(r);
+  const gl = srgbChannelToLinear(g);
+  const bl = srgbChannelToLinear(b);
+
+  return {
+    x: rl * 0.4124564 + gl * 0.3575761 + bl * 0.1804375,
+    y: rl * 0.2126729 + gl * 0.7151522 + bl * 0.072175,
+    z: rl * 0.0193339 + gl * 0.119192 + bl * 0.9503041,
+  };
+}
+
+function xyzToRgb({ x, y, z }: Xyz): RGBColor {
+  const rl = x * 3.2404542 + y * -1.5371385 + z * -0.4985314;
+  const gl = x * -0.969266 + y * 1.8760108 + z * 0.041556;
+  const bl = x * 0.0556434 + y * -0.2040259 + z * 1.0572252;
+
+  return [
+    linearChannelToSrgb(rl),
+    linearChannelToSrgb(gl),
+    linearChannelToSrgb(bl),
+  ];
+}
+
+function labForwardTransform(t: number): number {
+  const delta = 6 / 29;
+  return t > delta ** 3 ? Math.cbrt(t) : t / (3 * delta ** 2) + 4 / 29;
+}
+
+function labInverseTransform(t: number): number {
+  const delta = 6 / 29;
+  return t > delta ? t ** 3 : 3 * delta ** 2 * (t - 4 / 29);
+}
+
+type Lab = { l: number; a: number; b: number };
+
+function rgbToLab(color: RGBColor): Lab {
+  const { x, y, z } = rgbToXyz(color);
+  const fx = labForwardTransform(x / D65.x);
+  const fy = labForwardTransform(y / D65.y);
+  const fz = labForwardTransform(z / D65.z);
+
+  return { l: 116 * fy - 16, a: 500 * (fx - fy), b: 200 * (fy - fz) };
+}
+
+function labToRgb({ l, a, b }: Lab): RGBColor {
+  const fy = (l + 16) / 116;
+  const fx = fy + a / 500;
+  const fz = fy - b / 200;
+
+  return xyzToRgb({
+    x: D65.x * labInverseTransform(fx),
+    y: D65.y * labInverseTransform(fy),
+    z: D65.z * labInverseTransform(fz),
+  });
+}
+
+function withChroma(lab: Lab, scale: number): Lab {
+  return { l: lab.l, a: lab.a * scale, b: lab.b * scale };
+}
+
+/**
+ * Binary-searches a colour's CIELAB lightness toward `targetPole` (0 or
+ * 100), returning the candidate closest to the original lightness that
+ * still clears `requiredRatio` against `fixed`, or null if even the pole
+ * itself can't reach it (at either full or reduced chroma).
+ */
+function walkLightnessToward(
+  original: RGBColor,
+  fixed: RGBColor,
+  targetPole: 0 | 100,
+  requiredRatio: number,
+): RGBColor | null {
+  const originalLab = rgbToLab(original);
+  const achieves = (lab: Lab) => rgb(labToRgb(lab), fixed);
+
+  const searchAtChroma = (chromaScale: number): RGBColor | null => {
+    const atPole = achieves(
+      withChroma({ ...originalLab, l: targetPole }, chromaScale),
+    );
+    if (atPole < requiredRatio + RATIO_BUFFER) return null;
+
+    // lo starts as a confirmed "doesn't clear the target" point (the
+    // original lightness - if it already cleared it, suggestAccessibleColor
+    // would have returned null before ever calling this), hi as a confirmed
+    // "clears it" point (the pole, just checked above). Standard bisection
+    // narrows both toward the boundary regardless of which is numerically
+    // larger, so this works whether targetPole is 0 or 100.
+    let lo: number = originalLab.l;
+    let hi: number = targetPole;
+
+    for (let i = 0; i < MAX_ITERATIONS; i++) {
+      const mid = (lo + hi) / 2;
+      const midRatio = achieves(
+        withChroma({ ...originalLab, l: mid }, chromaScale),
+      );
+
+      if (midRatio >= requiredRatio + RATIO_BUFFER) {
+        hi = mid;
+      } else {
+        lo = mid;
+      }
+    }
+
+    return labToRgb(withChroma({ ...originalLab, l: hi }, chromaScale));
+  };
+
+  // Pass 1: pure lightness walk, hue/chroma unchanged.
+  const pureLightness = searchAtChroma(1);
+  if (pureLightness) return pureLightness;
+
+  // Pass 2 (rare): very saturated colours can't reach some targets at full
+  // saturation while staying in-gamut. Reduce chroma too and try again.
+  // Verified reachable, not just theoretical: e.g. pure blue [0,0,255]
+  // against mid-gray [160,160,160] at AAA needs this pass - full-chroma
+  // clipping alone doesn't get dark enough, chroma-reduced does.
+  return searchAtChroma(0.5);
+}
+
+/**
+ * Suggests an accessible replacement for either the foreground or the
+ * background colour of a failing contrast pair, walking CIELAB lightness
+ * toward whichever pole (darker or lighter) actually increases contrast -
+ * see the `adjustment` field on the result, which isn't assumed from
+ * `direction` alone. Returns null if the pair is already compliant at the
+ * requested level, or if no in-gamut candidate exists in either direction.
+ */
+export function suggestAccessibleColor(
+  foreground: RGBColor,
+  background: RGBColor,
+  fontSize: number,
+  isBold: boolean,
+  targetLevel: "AA" | "AAA",
+  direction: ColorFixDirection,
+): ColorFixSuggestion | null {
+  const requiredRatio = getRequiredRatio(
+    targetLevel,
+    isLargeText(fontSize, isBold),
+  );
+  const currentRatio = rgb(foreground, background);
+
+  if (currentRatio >= requiredRatio) return null;
+
+  const adjustable = direction === "foreground" ? foreground : background;
+  const fixed = direction === "foreground" ? background : foreground;
+  const originalL = rgbToLab(adjustable).l;
+
+  const darker = walkLightnessToward(adjustable, fixed, 0, requiredRatio);
+  const lighter = walkLightnessToward(adjustable, fixed, 100, requiredRatio);
+
+  const candidates: Array<{
+    color: RGBColor;
+    adjustment: "darker" | "lighter";
+  }> = [];
+  if (darker) candidates.push({ color: darker, adjustment: "darker" });
+  if (lighter) candidates.push({ color: lighter, adjustment: "lighter" });
+
+  if (candidates.length === 0) return null;
+
+  // Prefer whichever reachable pole required the smaller lightness change -
+  // closer to the designer's original colour, not the most extreme option.
+  const best = candidates.reduce((closest, candidate) => {
+    const candidateDelta = Math.abs(rgbToLab(candidate.color).l - originalL);
+    const closestDelta = Math.abs(rgbToLab(closest.color).l - originalL);
+    return candidateDelta < closestDelta ? candidate : closest;
+  });
+
+  return {
+    color: best.color,
+    ratio: rgb(best.color, fixed),
+    adjustment: best.adjustment,
+  };
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,6 +6,7 @@ export const MESSAGE_TYPES = {
   CANCEL_QUICKCHECK: "cancel-quickcheck",
   SCAN: "scan",
   UPDATE_FONT_SIZE: "update-font-size",
+  UPDATE_FILL_COLOR: "update-fill-color",
   NAVIGATE: "navigate",
   GET_IMAGE_DATA: "get-image-data",
   GENERATE_ALT_TEXT: "generate-alt-text",

--- a/src/lib/figmaUtils/index.test.ts
+++ b/src/lib/figmaUtils/index.test.ts
@@ -8,6 +8,7 @@ import {
   isTouchTarget,
   isTouchTargetTooClose,
   isTouchTargetTooSmall,
+  replaceTopmostVisibleSolidFillColor,
 } from "./index";
 
 function fakeNode(
@@ -70,6 +71,62 @@ describe("extractForegroundColor", () => {
     const invisibleSolid = solidFill(1, 1, 1, false);
 
     expect(extractForegroundColor([gradient, invisibleSolid])).toBeNull();
+  });
+});
+
+describe("replaceTopmostVisibleSolidFillColor", () => {
+  it("replaces only the topmost visible solid fill's colour", () => {
+    const fills = [solidFill(1, 0, 0), solidFill(0, 0, 1)];
+
+    const updated = replaceTopmostVisibleSolidFillColor(fills, {
+      r: 0,
+      g: 1,
+      b: 0,
+    });
+
+    expect(updated).toEqual([solidFill(1, 0, 0), solidFill(0, 1, 0)]);
+  });
+
+  it("leaves every other fill untouched, including non-solid ones", () => {
+    const gradient = { type: "GRADIENT_LINEAR", visible: true } as Paint;
+    const fills = [gradient, solidFill(1, 0, 0)];
+
+    const updated = replaceTopmostVisibleSolidFillColor(fills, {
+      r: 0,
+      g: 0,
+      b: 1,
+    });
+
+    expect(updated?.[0]).toBe(gradient);
+    expect(updated?.[1]).toEqual(solidFill(0, 0, 1));
+  });
+
+  it("skips an invisible solid fill on top and replaces the visible one beneath it", () => {
+    const fills = [solidFill(1, 0, 0), solidFill(0, 0, 1, false)];
+
+    const updated = replaceTopmostVisibleSolidFillColor(fills, {
+      r: 0,
+      g: 1,
+      b: 0,
+    });
+
+    expect(updated).toEqual([solidFill(0, 1, 0), solidFill(0, 0, 1, false)]);
+  });
+
+  it("returns null when there is no visible solid fill to replace", () => {
+    const gradient = { type: "GRADIENT_LINEAR", visible: true } as Paint;
+
+    expect(
+      replaceTopmostVisibleSolidFillColor([gradient], { r: 0, g: 0, b: 0 }),
+    ).toBeNull();
+  });
+
+  it("does not mutate the original fills array", () => {
+    const fills = [solidFill(1, 0, 0)];
+
+    replaceTopmostVisibleSolidFillColor(fills, { r: 0, g: 1, b: 0 });
+
+    expect(fills).toEqual([solidFill(1, 0, 0)]);
   });
 });
 
@@ -224,12 +281,18 @@ describe("createTypographyIssue", () => {
 });
 
 describe("createContrastIssue", () => {
-  it("builds a CONTRAST issue with the given colours and score", () => {
+  it("builds a CONTRAST issue with the given colours, score, and background node identity", () => {
     const node = fakeTextNode({ id: "text-2", characters: "Hi", name: "Body" });
     const contrastScore = { compliance: "Fail" as const, ratio: 2.1 };
+    const background = {
+      color: [255, 255, 255] as [number, number, number],
+      nodeId: "bg-1",
+      nodeName: "Card",
+      sharedWithCount: 2,
+    };
 
     expect(
-      createContrastIssue(node, contrastScore, [0, 0, 0], [255, 255, 255]),
+      createContrastIssue(node, contrastScore, [0, 0, 0], background, true),
     ).toEqual({
       description: "Text contrast is below WCAG AA standard.",
       severity: "critical",
@@ -245,19 +308,28 @@ describe("createContrastIssue", () => {
         nodeType: "TEXT",
         foregroundColor: [0, 0, 0],
         backgroundColor: [255, 255, 255],
+        backgroundNodeId: "bg-1",
+        backgroundNodeName: "Card",
+        backgroundSharedWithCount: 2,
+        isBold: true,
       },
     });
   });
 
-  it("leaves backgroundColor undefined instead of defaulting to white when none was detected", () => {
+  it("leaves every background-related field undefined instead of defaulting when none was detected", () => {
     const issue = createContrastIssue(
       fakeTextNode(),
       { compliance: "Fail", ratio: 2.1 },
       [0, 0, 0],
-      undefined,
+      null,
+      false,
     );
 
     expect(issue.nodeData.backgroundColor).toBeUndefined();
+    expect(issue.nodeData.backgroundNodeId).toBeUndefined();
+    expect(issue.nodeData.backgroundNodeName).toBeUndefined();
+    expect(issue.nodeData.backgroundSharedWithCount).toBeUndefined();
+    expect(issue.nodeData.isBold).toBe(false);
   });
 });
 

--- a/src/lib/figmaUtils/index.ts
+++ b/src/lib/figmaUtils/index.ts
@@ -7,6 +7,7 @@ import {
   TOUCH_TARGET_KEYWORDS,
 } from "../constants";
 import {
+  BackgroundColorResult,
   figmaRGBtoRGBColor,
   getBackgroundColorForNode,
   getContrastCompliance,
@@ -37,25 +38,60 @@ export function postMessageToBackend(
 }
 
 /**
- * Extracts the foreground color from the given Paint array.
+ * Finds the index of the topmost visible SOLID fill in a Paint array.
  *
  * Figma's fills array is ordered back-to-front — the last entry is
  * rendered on top of the others — so this scans from the end to find
  * the topmost visible SOLID fill, which is what's actually rendered.
+ *
+ * @param {Paint[]} fills - Array of Paint objects from a Figma node.
+ * @returns {number} The index of the topmost visible solid fill, or -1 if
+ * none exists (e.g. gradient/image-only fills).
+ */
+function findTopmostVisibleSolidFillIndex(fills: Paint[]): number {
+  for (let i = fills.length - 1; i >= 0; i--) {
+    const fill = fills[i];
+    if (fill.type === "SOLID" && fill.visible !== false) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Extracts the foreground color from the given Paint array.
  *
  * @param {Paint[]} nodeFills - Array of Paint objects from a Figma node.
  * @returns {RGBColor | null} The rendered foreground color, or null if
  * no visible solid fill exists (e.g. gradient/image-only fills).
  */
 export const extractForegroundColor = (nodeFills: Paint[]): RGBColor | null => {
-  for (let i = nodeFills.length - 1; i >= 0; i--) {
-    const fill = nodeFills[i];
-    if (fill.type === "SOLID" && fill.visible !== false) {
-      return figmaRGBtoRGBColor(fill.color);
-    }
-  }
-  return null;
+  const index = findTopmostVisibleSolidFillIndex(nodeFills);
+  if (index === -1) return null;
+  return figmaRGBtoRGBColor((nodeFills[index] as SolidPaint).color);
 };
+
+/**
+ * Returns a copy of `fills` with the topmost visible SOLID fill's colour
+ * replaced by `color` — the same fill `extractForegroundColor` would report
+ * as "what's actually rendered" — so a suggested fix touches exactly the
+ * fill that was measured, rather than overwriting the whole fills array and
+ * losing other paints/gradients underneath it.
+ *
+ * @param {Paint[]} fills - Array of Paint objects from a Figma node.
+ * @param {RGB} color - The replacement colour, in Figma's 0-1 RGB format.
+ * @returns {Paint[] | null} The updated fills array, or null if there was
+ * no visible solid fill to replace.
+ */
+export function replaceTopmostVisibleSolidFillColor(
+  fills: Paint[],
+  color: RGB,
+): Paint[] | null {
+  const index = findTopmostVisibleSolidFillIndex(fills);
+  if (index === -1) return null;
+
+  return fills.map((fill, i) => (i === index ? { ...fill, color } : fill));
+}
 
 /**
  * Creates a typography issue object for the given TextNode.
@@ -227,14 +263,16 @@ export const createTouchTargetIssue = (
  * @param {TextNode} node - The Figma TextNode to analyze.
  * @param {string} contrastScore - The WCAG contrast score.
  * @param {RGBColor} foregroundColor - The text's foreground color in RGB.
- * @param {RGBColor | null} backgroundColor - The background color in RGB or null.
+ * @param {BackgroundColorResult | null} background - The resolved background colour plus which node contributed it, or null.
+ * @param {boolean} isBold - Whether the text is bold, for the large-text contrast threshold.
  * @returns {IssueX} An issue object detailing the contrast issue.
  */
 export const createContrastIssue = (
   node: TextNode,
   contrastScore: contrastScore,
   foregroundColor: RGBColor,
-  backgroundColor: RGBColor | undefined,
+  background: BackgroundColorResult | null,
+  isBold: boolean,
 ): IssueX => ({
   description: "Text contrast is below WCAG AA standard.",
   severity: "critical",
@@ -249,7 +287,11 @@ export const createContrastIssue = (
     name: node.name,
     nodeType: node.type,
     foregroundColor,
-    backgroundColor: backgroundColor, // || [255, 255, 255]
+    backgroundColor: background?.color,
+    backgroundNodeId: background?.nodeId,
+    backgroundNodeName: background?.nodeName,
+    backgroundSharedWithCount: background?.sharedWithCount,
+    isBold,
   },
 });
 
@@ -261,7 +303,8 @@ export async function analyzeTextNodeForContrastIssue(
 
   if ("fills" in node) {
     const foregroundColor = extractForegroundColor(node.fills as Paint[]);
-    const backgroundColor = getBackgroundColorForNode(node);
+    const backgroundResult = getBackgroundColorForNode(node);
+    const backgroundColor = backgroundResult?.color;
     const fontWeight: number | symbol = node.fontWeight;
     const fontSize: number | symbol = node.fontSize;
 
@@ -300,7 +343,8 @@ export async function analyzeTextNodeForContrastIssue(
               node,
               contrastScore,
               foregroundColor,
-              backgroundColor,
+              backgroundResult,
+              isBold,
             ),
           );
         }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,6 +44,23 @@ export type NodeDataType = {
   name: string;
   foregroundColor?: RGBColor;
   backgroundColor?: RGBColor;
+  /**
+   * Identity of the node that contributed backgroundColor, and how many
+   * other nodes share its fill - undefined when backgroundColor is
+   * undefined, or when the node came from resolving a contributing solid
+   * fill couldn't be determined. Used by the contrast "fix it" suggester
+   * (roadmap/COLOR_FIX_SUGGESTER_PLAN.md) to know which node to mutate for
+   * the "lighten background" direction, and whether to disclose that it's
+   * shared with other layers before applying.
+   */
+  backgroundNodeId?: string;
+  backgroundNodeName?: string;
+  backgroundSharedWithCount?: number;
+  /** Needed to correctly apply WCAG's large-text ratio threshold when
+   * suggesting a contrast fix - not derivable after the fact from
+   * contrastScore alone, since a "Fail" result doesn't say whether it was
+   * measured as large or normal text. */
+  isBold?: boolean;
   nodeType: NodeType | NodeType[];
   requiredSize?: string;
 };

--- a/src/lib/utils/index.test.ts
+++ b/src/lib/utils/index.test.ts
@@ -180,6 +180,7 @@ function nodeWithEarlierSibling(
 ): SceneNode {
   const sibling = {
     id: "sibling",
+    name: "Sibling shape",
     fills: siblingFills,
     absoluteBoundingBox: siblingBounds,
   };
@@ -198,12 +199,33 @@ describe("getBackgroundColorForNode", () => {
     expect(getBackgroundColorForNode(node)).toBeNull();
   });
 
-  it("returns the parent's solid fill color", () => {
+  it("returns the parent's solid fill color, id, and name, with a zero shared count when it has no other children", () => {
     const node = {
-      parent: { fills: [solidFill(1, 0, 0)] },
+      id: "node",
+      parent: { id: "parent-1", name: "Card", fills: [solidFill(1, 0, 0)] },
     } as unknown as SceneNode;
 
-    expect(getBackgroundColorForNode(node)).toEqual([255, 0, 0]);
+    expect(getBackgroundColorForNode(node)).toEqual({
+      color: [255, 0, 0],
+      nodeId: "parent-1",
+      nodeName: "Card",
+      sharedWithCount: 0,
+    });
+  });
+
+  it("counts every other child as sharing the parent's own fill, since they all sit on it by definition", () => {
+    const node = { id: "node" };
+    const parent = {
+      id: "parent-1",
+      name: "Card",
+      fills: [solidFill(1, 0, 0)],
+      children: [node, { id: "sibling-1" }, { id: "sibling-2" }],
+    };
+    (node as Record<string, unknown>).parent = parent;
+
+    expect(
+      getBackgroundColorForNode(node as unknown as SceneNode)?.sharedWithCount,
+    ).toBe(2);
   });
 
   it("skips an invisible parent fill and returns null when no sibling covers it", () => {
@@ -214,11 +236,40 @@ describe("getBackgroundColorForNode", () => {
     expect(getBackgroundColorForNode(node)).toBeNull();
   });
 
-  it("falls back to an overlapping earlier sibling's fill when the parent has no fill", () => {
+  it("falls back to an overlapping earlier sibling's fill, id, and name when the parent has no fill", () => {
     const bounds = { x: 0, y: 0, width: 100, height: 100 };
     const node = nodeWithEarlierSibling(bounds, bounds, [solidFill(0, 1, 0)]);
 
-    expect(getBackgroundColorForNode(node)).toEqual([0, 255, 0]);
+    expect(getBackgroundColorForNode(node)).toEqual({
+      color: [0, 255, 0],
+      nodeId: "sibling",
+      nodeName: "Sibling shape",
+      sharedWithCount: 0,
+    });
+  });
+
+  it("counts other siblings that also overlap the same contributing sibling", () => {
+    const bgSibling = {
+      id: "bg-sibling",
+      name: "Background shape",
+      fills: [solidFill(0, 1, 0)],
+      absoluteBoundingBox: { x: 0, y: 0, width: 100, height: 100 },
+    };
+    const otherSibling = {
+      id: "other-sibling",
+      // No fills - shouldn't be picked as the contributing node itself,
+      // but should still count toward bgSibling's sharedWithCount.
+      absoluteBoundingBox: { x: 10, y: 10, width: 20, height: 20 },
+    };
+    const node: Record<string, unknown> = {
+      id: "node",
+      absoluteBoundingBox: { x: 0, y: 0, width: 100, height: 100 },
+    };
+    node.parent = { fills: [], children: [bgSibling, otherSibling, node] };
+
+    expect(
+      getBackgroundColorForNode(node as unknown as SceneNode)?.sharedWithCount,
+    ).toBe(1);
   });
 
   it("ignores a non-overlapping earlier sibling and returns null", () => {

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -234,7 +234,26 @@ export function overlaps(nodeA: SceneNode, nodeB: SceneNode): boolean {
   );
 }
 
-export function getBackgroundColorForNode(node: SceneNode): RGBColor | null {
+export type BackgroundColorResult = {
+  color: RGBColor;
+  nodeId: string;
+  nodeName: string;
+  /**
+   * How many other nodes also depend on this same contributing node's fill.
+   * Case 1 (direct parent fill): every other child of that parent sits on
+   * the same fill by definition of nesting, so this is exact, not a guess.
+   * Case 2 (sibling-overlap fallback): how many other siblings also overlap
+   * the same contributing sibling - i.e. other elements sitting on the same
+   * background shape. Used by the contrast "fix it" suggester
+   * (roadmap/COLOR_FIX_SUGGESTER_PLAN.md) to disclose when changing this
+   * fill could visually affect more than just the node being fixed.
+   */
+  sharedWithCount: number;
+};
+
+export function getBackgroundColorForNode(
+  node: SceneNode,
+): BackgroundColorResult | null {
   if (!node.parent) return null;
 
   const parent = node.parent;
@@ -245,7 +264,17 @@ export function getBackgroundColorForNode(node: SceneNode): RGBColor | null {
       (fill) => fill.type === "SOLID" && fill.visible,
     );
     if (solidFill && "color" in solidFill) {
-      return figmaRGBtoRGBColor(solidFill.color);
+      const sharedWithCount =
+        "children" in parent
+          ? parent.children.filter((child) => child.id !== node.id).length
+          : 0;
+
+      return {
+        color: figmaRGBtoRGBColor(solidFill.color),
+        nodeId: parent.id,
+        nodeName: parent.name,
+        sharedWithCount,
+      };
     }
   }
 
@@ -260,7 +289,19 @@ export function getBackgroundColorForNode(node: SceneNode): RGBColor | null {
             (fill) => fill.type === "SOLID" && fill.visible,
           );
           if (solidFill && "color" in solidFill) {
-            return figmaRGBtoRGBColor(solidFill.color);
+            const sharedWithCount = parent.children.filter(
+              (other) =>
+                other.id !== node.id &&
+                other.id !== sibling.id &&
+                overlaps(sibling, other),
+            ).length;
+
+            return {
+              color: figmaRGBtoRGBColor(solidFill.color),
+              nodeId: sibling.id,
+              nodeName: sibling.name,
+              sharedWithCount,
+            };
           }
         }
       }


### PR DESCRIPTION
## Summary
- Adds a "Suggested fixes" card to the contrast issue detail panel: for a failing CONTRAST issue, suggests two accessible colour fixes (darken text or lighten background, whichever direction actually improves contrast) computed via a perceptually-uniform CIELAB lightness search (`src/lib/colorFix`) rather than a naive HSL walk.
- AA/AAA target toggle recomputes both suggestions live.
- Tapping a swatch selects/scrolls to the relevant node in Figma; Apply mutates the topmost visible SOLID fill via a new `UPDATE_FILL_COLOR` message + `handleUpdateFillColor` in `plugin/code.ts`, with a toast when the background direction changes a fill shared with other layers.
- `getBackgroundColorForNode` now also reports which node contributed the background colour and how many other nodes share its fill, used for the apply/navigate targeting and the "shared with N other layers" disclosure line.
- Follow-up refactor: extracted the suggested-fixes card out of `IssuesNavigator` into its own `ContrastFixSuggester` component (folder + `index.tsx`/`index.test.tsx` convention) once it grew to ~160 lines inline - no behaviour change.
- Added a consistent card border across the issue-detail panels (`AccessibilityValidator`, `IssuesOverviewList`, `TouchTargetNavigator`, `AltTextGenerator`) that were missing it, for visual consistency with the new card.

## Test plan
- [x] `src/lib/colorFix/index.test.ts` - darken vs lighten selection, AA/AAA thresholds, chroma-reduction fallback, null when already compliant/unreachable
- [x] `src/components/organisms/ContrastFixSuggester/index.test.tsx` and `IssuesNavigator/index.test.tsx` - toggle recompute, swatch navigation, Apply updates local state + posts `UPDATE_FILL_COLOR`/`NOTIFY`, shared-background disclosure
- [x] `src/lib/figmaUtils/index.test.ts` - new `backgroundNodeId`/`backgroundSharedWithCount` fields
- [x] `npm run test` (199/199), `npm run lint`, `tsc -b`, `npm run build` all clean
- [x] Manually verified in Figma dev mode: suggestions/AA-AAA toggle, swatch navigation, Apply on both foreground and background (including the shared-fill toast), and the non-solid-fill guard path - confirmed working