### PR TITLE
feat(a11y): add global AA/AAA target-level toggle for contrast detection

### DIFF
--- a/src/components/organisms/ContrastFixSuggester/index.tsx
+++ b/src/components/organisms/ContrastFixSuggester/index.tsx
@@ -1,11 +1,9 @@
+import TargetLevelToggle from "@/components/organisms/TargetLevelToggle";
 import { Button } from "@/components/ui/button";
 import { ColorFixDirection, ColorFixSuggestion } from "@/lib/colorFix";
+import { TargetLevel } from "@/lib/types";
 import { cn, figmaRGBtoHex, getSeverityStyles } from "@/lib/utils";
 import { Check } from "lucide-react";
-
-export type TargetLevel = "AA" | "AAA";
-
-const TARGET_LEVELS: readonly TargetLevel[] = ["AA", "AAA"] as const;
 
 export type ContrastFixSuggesterProps = {
   targetLevel: TargetLevel;
@@ -31,33 +29,14 @@ export default function ContrastFixSuggester({
 }: ContrastFixSuggesterProps) {
   return (
     <div className="grid w-full rounded-xl border border-rose-50/10 bg-dark-shade p-3">
-      <div className="mb-2 flex items-center justify-between gap-4">
-        <h4 className="text-sm font-medium text-grey">Suggested fixes</h4>
-        <div
-          role="radiogroup"
-          aria-label="Target compliance level"
-          className="inline-flex items-center gap-x-1"
-        >
-          {TARGET_LEVELS.map((level) => (
-            <Button
-              key={level}
-              type="button"
-              title={`Target WCAG ${level}`}
-              role="radio"
-              aria-checked={targetLevel === level}
-              variant="ghost"
-              size="sm"
-              className={cn(
-                "h-6 px-2 text-xs",
-                targetLevel === level &&
-                  "bg-dark text-accent ring-1 ring-accent",
-              )}
-              onClick={() => onTargetLevelChange(level)}
-            >
-              {level}
-            </Button>
-          ))}
-        </div>
+      <div className="mb-2">
+        <TargetLevelToggle
+          value={targetLevel}
+          onChange={onTargetLevelChange}
+          label={
+            <h4 className="text-sm font-medium text-grey">Suggested fixes</h4>
+          }
+        />
       </div>
 
       {!foregroundSuggestion && !backgroundSuggestion ? (

--- a/src/components/organisms/IssuesNavigator/index.tsx
+++ b/src/components/organisms/IssuesNavigator/index.tsx
@@ -1,6 +1,4 @@
-import ContrastFixSuggester, {
-  TargetLevel,
-} from "@/components/organisms/ContrastFixSuggester";
+import ContrastFixSuggester from "@/components/organisms/ContrastFixSuggester";
 import IssueDetailRow from "@/components/organisms/IssueDetailRow";
 import IssuesWrapper from "@/components/organisms/IssuesWrapper";
 import Input from "@/components/ui/input";
@@ -11,7 +9,7 @@ import {
 } from "@/lib/colorFix";
 import { MESSAGE_TYPES, MIN_FONT_SIZE } from "@/lib/constants";
 import { postMessageToBackend } from "@/lib/figmaUtils";
-import { IssueX } from "@/lib/types";
+import { IssueX, TargetLevel } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
 import {
   cn,

--- a/src/components/organisms/IssuesOverviewList/index.test.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.test.tsx
@@ -60,6 +60,7 @@ const defaultState = {
   scanning: false,
   currentRoute: "INDEX" as const,
   selectedType: "" as const,
+  targetLevel: "AA" as const,
 };
 
 describe("IssuesOverviewList", () => {
@@ -148,6 +149,45 @@ describe("IssuesOverviewList", () => {
 
     expect(useIssuesStore.getState().selectedType).toBe("TYPOGRAPHY");
     expect(useIssuesStore.getState().currentRoute).toBe("ISSUE_LIST_VIEW");
+  });
+
+  it("does not show the WCAG target toggle when there are no contrast issues", () => {
+    useIssuesStore.setState({ issues: [typographyIssue] });
+    render(<IssuesOverviewList />);
+
+    expect(screen.queryByText("WCAG target")).toBeNull();
+  });
+
+  it("shows the WCAG target toggle when there are contrast issues, defaulting to AA", () => {
+    useIssuesStore.setState({
+      issues: [contrastFailIssue, contrastPassIssue],
+    });
+    render(<IssuesOverviewList />);
+
+    expect(screen.getByText("WCAG target")).toBeVisible();
+    expect(screen.getByRole("radio", { name: "AA" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+  });
+
+  it("counts an AA-passing contrast issue as failing once the target level is switched to AAA", async () => {
+    const user = userEvent.setup();
+    useIssuesStore.setState({
+      issues: [contrastFailIssue, contrastPassIssue],
+    });
+    render(<IssuesOverviewList />);
+
+    expect(
+      screen.getByText("There are 1 issues detected on this screen."),
+    ).toBeVisible();
+
+    await user.click(screen.getByRole("radio", { name: "AAA" }));
+
+    expect(useIssuesStore.getState().targetLevel).toBe("AAA");
+    expect(
+      screen.getByText("There are 2 issues detected on this screen."),
+    ).toBeVisible();
   });
 
   it("shows the category breakdown chart on the Report tab only when there are counted issues", async () => {

--- a/src/components/organisms/IssuesOverviewList/index.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.tsx
@@ -1,3 +1,4 @@
+import TargetLevelToggle from "@/components/organisms/TargetLevelToggle";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ISSUES_TYPES, MESSAGE_TYPES } from "@/lib/constants";
@@ -5,7 +6,12 @@ import ISSUE_TYPE_LABELS from "@/lib/issueTypeLabels";
 import { ISSUES_DATA_SCHEMA } from "@/lib/issuesData";
 import { IssueType, IssueX } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
-import { cn, getRouteForIssueType, getSeverityStyles } from "@/lib/utils";
+import {
+  cn,
+  contrastFailsTargetLevel,
+  getRouteForIssueType,
+  getSeverityStyles,
+} from "@/lib/utils";
 import { saveAs } from "file-saver";
 import { ChevronLeft, ChevronRight, RefreshCcw } from "lucide-react";
 import { useEffect } from "react";
@@ -22,20 +28,22 @@ export default function IssuesOverviewList() {
     setSelectedType,
     navigateTo,
     rescanIssues,
+    targetLevel,
+    setTargetLevel,
   } = useIssuesStore();
 
   const issuesGroupListRecords = issues.filter((issue) => {
-    if (issue.type && ISSUES_TYPES.includes(issue.type)) {
-      if (
-        issue.type === "CONTRAST" &&
-        issue.nodeData.contrastScore?.compliance === "Fail"
-      ) {
-        return true;
-      }
-      return issue.type !== "CONTRAST";
+    if (!issue.type || !ISSUES_TYPES.includes(issue.type)) return false;
+    if (issue.type === "CONTRAST") {
+      return contrastFailsTargetLevel(
+        issue.nodeData.contrastScore?.compliance,
+        targetLevel,
+      );
     }
-    return false;
+    return true;
   });
+
+  const hasContrastIssues = issues.some((issue) => issue.type === "CONTRAST");
 
   // Listen for messages from the backend
   useEffect(() => {
@@ -185,6 +193,18 @@ export default function IssuesOverviewList() {
 
       {!scanning ? (
         <div className="flex size-full flex-col">
+          {hasContrastIssues && (
+            <TargetLevelToggle
+              value={targetLevel}
+              onChange={setTargetLevel}
+              label={
+                <span className="text-sm font-medium text-grey">
+                  WCAG target
+                </span>
+              }
+            />
+          )}
+
           <Tabs defaultValue="issues">
             <TabsList className="mb-4 mt-2 flex space-x-4 bg-dark-shade !py-6">
               <TabsTrigger value="issues">Issues</TabsTrigger>

--- a/src/components/organisms/TargetLevelToggle/index.test.tsx
+++ b/src/components/organisms/TargetLevelToggle/index.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import TargetLevelToggle from "./index";
+
+describe("TargetLevelToggle", () => {
+  it("renders the label alongside the AA/AAA radio group", () => {
+    render(
+      <TargetLevelToggle
+        value="AA"
+        onChange={vi.fn()}
+        label={<span>WCAG target</span>}
+      />,
+    );
+
+    expect(screen.getByText("WCAG target")).toBeVisible();
+    expect(
+      screen.getByRole("radiogroup", { name: "Target compliance level" }),
+    ).toBeVisible();
+  });
+
+  it("marks the current value's radio as checked and the other as unchecked", () => {
+    render(<TargetLevelToggle value="AAA" onChange={vi.fn()} />);
+
+    expect(screen.getByRole("radio", { name: "AA" })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+    expect(screen.getByRole("radio", { name: "AAA" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+  });
+
+  it("calls onChange with the clicked level", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TargetLevelToggle value="AA" onChange={onChange} />);
+
+    await user.click(screen.getByRole("radio", { name: "AAA" }));
+
+    expect(onChange).toHaveBeenCalledWith("AAA");
+  });
+
+  it("renders without a label when none is passed", () => {
+    render(<TargetLevelToggle value="AA" onChange={vi.fn()} />);
+
+    expect(
+      screen.getByRole("radiogroup", { name: "Target compliance level" }),
+    ).toBeVisible();
+  });
+});

--- a/src/components/organisms/TargetLevelToggle/index.test.tsx
+++ b/src/components/organisms/TargetLevelToggle/index.test.tsx
@@ -49,4 +49,52 @@ describe("TargetLevelToggle", () => {
       screen.getByRole("radiogroup", { name: "Target compliance level" }),
     ).toBeVisible();
   });
+
+  it("only tabs to the checked radio, keeping the other out of the tab sequence", () => {
+    render(<TargetLevelToggle value="AA" onChange={vi.fn()} />);
+
+    expect(screen.getByRole("radio", { name: "AA" })).toHaveAttribute(
+      "tabIndex",
+      "0",
+    );
+    expect(screen.getByRole("radio", { name: "AAA" })).toHaveAttribute(
+      "tabIndex",
+      "-1",
+    );
+  });
+
+  it("moves focus and selection to the next radio on ArrowRight, wrapping at the end", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TargetLevelToggle value="AAA" onChange={onChange} />);
+
+    screen.getByRole("radio", { name: "AAA" }).focus();
+    await user.keyboard("[ArrowRight]");
+
+    expect(onChange).toHaveBeenCalledWith("AA");
+    expect(screen.getByRole("radio", { name: "AA" })).toHaveFocus();
+  });
+
+  it("moves focus and selection to the previous radio on ArrowLeft, wrapping at the start", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TargetLevelToggle value="AA" onChange={onChange} />);
+
+    screen.getByRole("radio", { name: "AA" }).focus();
+    await user.keyboard("[ArrowLeft]");
+
+    expect(onChange).toHaveBeenCalledWith("AAA");
+    expect(screen.getByRole("radio", { name: "AAA" })).toHaveFocus();
+  });
+
+  it("treats ArrowDown the same as ArrowRight and ArrowUp the same as ArrowLeft", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TargetLevelToggle value="AA" onChange={onChange} />);
+
+    screen.getByRole("radio", { name: "AA" }).focus();
+    await user.keyboard("[ArrowDown]");
+
+    expect(onChange).toHaveBeenLastCalledWith("AAA");
+  });
 });

--- a/src/components/organisms/TargetLevelToggle/index.tsx
+++ b/src/components/organisms/TargetLevelToggle/index.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@/components/ui/button";
+import { TARGET_LEVELS } from "@/lib/constants";
+import { TargetLevel } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { ReactNode } from "react";
+
+export type TargetLevelToggleProps = {
+  value: TargetLevel;
+  onChange: (level: TargetLevel) => void;
+  label?: ReactNode;
+};
+
+export default function TargetLevelToggle({
+  value,
+  onChange,
+  label,
+}: TargetLevelToggleProps) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      {label}
+      <div
+        role="radiogroup"
+        aria-label="Target compliance level"
+        className="inline-flex items-center gap-x-1"
+      >
+        {TARGET_LEVELS.map((level) => (
+          <Button
+            key={level}
+            type="button"
+            title={`Target WCAG ${level}`}
+            role="radio"
+            aria-checked={value === level}
+            variant="ghost"
+            size="sm"
+            className={cn(
+              "h-6 px-2 text-xs",
+              value === level && "bg-dark text-accent ring-1 ring-accent",
+            )}
+            onClick={() => onChange(level)}
+          >
+            {level}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/organisms/TargetLevelToggle/index.tsx
+++ b/src/components/organisms/TargetLevelToggle/index.tsx
@@ -2,7 +2,7 @@ import { Button } from "@/components/ui/button";
 import { TARGET_LEVELS } from "@/lib/constants";
 import { TargetLevel } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { ReactNode } from "react";
+import { KeyboardEvent, ReactNode, useRef } from "react";
 
 export type TargetLevelToggleProps = {
   value: TargetLevel;
@@ -15,6 +15,34 @@ export default function TargetLevelToggle({
   onChange,
   label,
 }: TargetLevelToggleProps) {
+  const radioRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  function focusAndSelect(index: number) {
+    const nextIndex = (index + TARGET_LEVELS.length) % TARGET_LEVELS.length;
+    radioRefs.current[nextIndex]?.focus();
+    onChange(TARGET_LEVELS[nextIndex]);
+  }
+
+  function handleRadioKeyDown(
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) {
+    switch (event.key) {
+      case "ArrowLeft":
+      case "ArrowUp":
+        event.preventDefault();
+        focusAndSelect(index - 1);
+        break;
+      case "ArrowRight":
+      case "ArrowDown":
+        event.preventDefault();
+        focusAndSelect(index + 1);
+        break;
+      default:
+        break;
+    }
+  }
+
   return (
     <div className="flex items-center justify-between gap-4">
       {label}
@@ -23,13 +51,17 @@ export default function TargetLevelToggle({
         aria-label="Target compliance level"
         className="inline-flex items-center gap-x-1"
       >
-        {TARGET_LEVELS.map((level) => (
+        {TARGET_LEVELS.map((level, index) => (
           <Button
             key={level}
+            ref={(node) => {
+              radioRefs.current[index] = node;
+            }}
             type="button"
             title={`Target WCAG ${level}`}
             role="radio"
             aria-checked={value === level}
+            tabIndex={value === level ? 0 : -1}
             variant="ghost"
             size="sm"
             className={cn(
@@ -37,6 +69,7 @@ export default function TargetLevelToggle({
               value === level && "bg-dark text-accent ring-1 ring-accent",
             )}
             onClick={() => onChange(level)}
+            onKeyDown={(event) => handleRadioKeyDown(event, index)}
           >
             {level}
           </Button>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,5 @@
 import ISSUE_TYPE_LABELS from "./issueTypeLabels";
-import { IssueType } from "./types";
+import { IssueType, TargetLevel } from "./types";
 
 export const MESSAGE_TYPES = {
   START_QUICKCHECK: "start-quickcheck",
@@ -29,3 +29,5 @@ export const MIN_TOUCH_TARGET_SIZE: number = 44;
 export const MIN_TOUCH_TARGET_SPACING: number = 8;
 
 export const TOUCH_TARGET_KEYWORDS = ["btn", "button", "link", "touch"];
+
+export const TARGET_LEVELS: readonly TargetLevel[] = ["AA", "AAA"] as const;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -25,6 +25,13 @@ export type contrastScore = {
   ratio: number;
 };
 
+/**
+ * Which WCAG conformance level detection/remediation is being held to.
+ * Global app state (see EnhancedIssuesStore.targetLevel) as well as the
+ * contrast fix suggester's own local target for a single suggestion.
+ */
+export type TargetLevel = "AA" | "AAA";
+
 export type Routes =
   | "INDEX"
   | "ISSUE_OVERVIEW_LIST_VIEW"
@@ -87,10 +94,13 @@ export interface EnhancedIssuesStore extends IssuesStore {
   scanning: boolean;
   selectedType: IssueType | ""; // Selected issue type; "" means no scan has run yet
   currentRoute: Routes;
+  /** Which WCAG level CONTRAST detection is held to across the whole scan - defaults to AA. */
+  targetLevel: TargetLevel;
   setScanning: (isScanning: boolean) => void; // Setter for scanning state
   setSingleIssue: (newIssue: IssueX | null) => void; // Setter for a single issue
   navigateTo: (route: Routes) => void;
   setSelectedType: (type: IssueType) => void;
+  setTargetLevel: (level: TargetLevel) => void;
   updateIssue: (id: string, updates: Partial<IssueX>) => void;
   getIssueGroupList: () => IssueX[];
   rescanIssues: () => void; // Rescan the document for issues

--- a/src/lib/useIssuesStore/index.test.ts
+++ b/src/lib/useIssuesStore/index.test.ts
@@ -136,4 +136,52 @@ describe("useIssuesStore.getIssueGroupList", () => {
 
     expect(useIssuesStore.getState().getIssueGroupList()).toEqual([]);
   });
+
+  it("defaults targetLevel to AA, so only Fail-compliance CONTRAST issues are flagged", () => {
+    useIssuesStore.setState({
+      issues: [
+        fakeContrastIssue("fail", "Fail"),
+        fakeContrastIssue("aa-pass", "AA"),
+        fakeContrastIssue("aaa-pass", "AAA"),
+      ],
+      selectedType: "CONTRAST",
+    });
+
+    expect(useIssuesStore.getState().targetLevel).toBe("AA");
+    expect(
+      useIssuesStore
+        .getState()
+        .getIssueGroupList()
+        .map((issue) => issue.nodeData.id),
+    ).toEqual(["fail"]);
+  });
+
+  it("flags AA-only compliant CONTRAST issues once the target level is AAA", () => {
+    useIssuesStore.setState({
+      issues: [
+        fakeContrastIssue("fail", "Fail"),
+        fakeContrastIssue("aa-pass", "AA"),
+        fakeContrastIssue("aaa-pass", "AAA"),
+      ],
+      selectedType: "CONTRAST",
+      targetLevel: "AAA",
+    });
+
+    expect(
+      useIssuesStore
+        .getState()
+        .getIssueGroupList()
+        .map((issue) => issue.nodeData.id),
+    ).toEqual(["fail", "aa-pass"]);
+  });
+});
+
+describe("useIssuesStore.setTargetLevel", () => {
+  it("updates targetLevel", () => {
+    useIssuesStore.setState({ targetLevel: "AA" });
+
+    useIssuesStore.getState().setTargetLevel("AAA");
+
+    expect(useIssuesStore.getState().targetLevel).toBe("AAA");
+  });
 });

--- a/src/lib/useIssuesStore/index.ts
+++ b/src/lib/useIssuesStore/index.ts
@@ -1,7 +1,14 @@
 import { create } from "zustand";
 import { MESSAGE_TYPES } from "../constants";
 import { postMessageToBackend } from "../figmaUtils";
-import { EnhancedIssuesStore, IssueType, IssueX, Routes } from "../types";
+import {
+  EnhancedIssuesStore,
+  IssueType,
+  IssueX,
+  Routes,
+  TargetLevel,
+} from "../types";
+import { contrastFailsTargetLevel } from "../utils";
 
 const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
   issues: [],
@@ -10,6 +17,7 @@ const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
   currentRoute: "INDEX", // Default route
   selectedType: "",
   scanning: false,
+  targetLevel: "AA",
   setScanning: (isScanning) =>
     set({
       scanning: isScanning,
@@ -25,18 +33,19 @@ const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
     set({ issues: newIssues });
   },
   setSelectedType: (type: IssueType) => set({ selectedType: type }),
+  setTargetLevel: (level: TargetLevel) => set({ targetLevel: level }),
   getIssueGroupList: () => {
-    const { issues, selectedType } = get();
+    const { issues, selectedType, targetLevel } = get();
 
     const response = issues.filter((issue) => {
       if (issue.type && issue.type === selectedType) {
-        if (
-          issue.type === "CONTRAST" &&
-          issue.nodeData.contrastScore?.compliance === "Fail"
-        ) {
-          return true;
+        if (issue.type === "CONTRAST") {
+          return contrastFailsTargetLevel(
+            issue.nodeData.contrastScore?.compliance,
+            targetLevel,
+          );
         }
-        return issue.type !== "CONTRAST";
+        return true;
       }
       return false;
     });

--- a/src/lib/utils/index.test.ts
+++ b/src/lib/utils/index.test.ts
@@ -10,6 +10,7 @@ import {
 import { RGBColor, rgb } from "wcag-contrast";
 import solidFill from "@/lib/test-utils/solidFill";
 import {
+  contrastFailsTargetLevel,
   copyToClipboard,
   getBackgroundColorForNode,
   getContrastCompliance,
@@ -338,6 +339,33 @@ describe("getRouteForIssueType", () => {
   it("routes everything else to ISSUE_LIST_VIEW", () => {
     expect(getRouteForIssueType("CONTRAST")).toBe("ISSUE_LIST_VIEW");
     expect(getRouteForIssueType("TYPOGRAPHY")).toBe("ISSUE_LIST_VIEW");
+  });
+});
+
+describe("contrastFailsTargetLevel", () => {
+  it("flags a Fail result at both AA and AAA", () => {
+    expect(contrastFailsTargetLevel("Fail", "AA")).toBe(true);
+    expect(contrastFailsTargetLevel("Fail", "AAA")).toBe(true);
+  });
+
+  it("does not flag an AA-passing result when the target is AA", () => {
+    expect(contrastFailsTargetLevel("AA", "AA")).toBe(false);
+    expect(contrastFailsTargetLevel("AA Large", "AA")).toBe(false);
+  });
+
+  it("flags an AA-only result as failing when the target is AAA", () => {
+    expect(contrastFailsTargetLevel("AA", "AAA")).toBe(true);
+    expect(contrastFailsTargetLevel("AA Large", "AAA")).toBe(true);
+  });
+
+  it("does not flag an AAA-passing result when the target is AAA", () => {
+    expect(contrastFailsTargetLevel("AAA", "AAA")).toBe(false);
+    expect(contrastFailsTargetLevel("AAA Large", "AAA")).toBe(false);
+  });
+
+  it("does not flag when there is no compliance result yet", () => {
+    expect(contrastFailsTargetLevel(undefined, "AA")).toBe(false);
+    expect(contrastFailsTargetLevel(undefined, "AAA")).toBe(false);
   });
 });
 

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,7 +1,7 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { rgb, RGBColor, score } from "wcag-contrast";
-import { copyToClipboardProps, IssueType, Routes } from "../types";
+import { copyToClipboardProps, IssueType, Routes, TargetLevel } from "../types";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -16,6 +16,27 @@ export function getRouteForIssueType(type: IssueType): Routes {
   return type === "TOUCH_TARGET_SIZE" || type === "TOUCH_TARGET_SPACING"
     ? "TOUCH_TARGET_ISSUE_LIST_VIEW"
     : "ISSUE_LIST_VIEW";
+}
+
+/**
+ * Whether a contrast result should be flagged as a failing issue at the
+ * given target level. `getContrastCompliance` reports the highest tier a
+ * pair actually achieved ("AAA"/"AA"/"AAA Large"/"AA Large"/"Fail"), not a
+ * pass/fail against one specific level - text that clears AA but not AAA
+ * comes back as "AA", which is a real issue if the target is AAA but not
+ * if it's AA. `compliance` is untyped (contrastScore.compliance: string)
+ * since it can be undefined when no contrast score exists yet.
+ */
+export function contrastFailsTargetLevel(
+  compliance: string | undefined,
+  targetLevel: TargetLevel,
+): boolean {
+  if (!compliance) return false;
+  if (compliance === "Fail") return true;
+  if (targetLevel === "AAA") {
+    return compliance === "AA" || compliance === "AA Large";
+  }
+  return false;
 }
 
 // Global state


### PR DESCRIPTION
## Summary
Closes the AA/AAA gap on the detection side (contrast half - see below for touch target): contrast issues were only ever flagged against a hardcoded AA bar, so text that clears AA but fails AAA was invisible as an issue even though the plugin already had the data to know that.

- New global `targetLevel` state (`useIssuesStore`, defaults to AA) drives a shared `contrastFailsTargetLevel` helper (`src/lib/utils`), used by both `getIssueGroupList` and `IssuesOverviewList`'s issue counting - the latter had its own duplicated copy of the same filter, deduped as part of this change.
- Toggle lives in `IssuesOverviewList`'s header, above the Issues/Report tabs since both tabs depend on the same filtered list (including CSV/JSON export), and only renders when there's at least one contrast issue to filter.
- Zero rescan needed: every scanned node's compliance tier is already stored, so toggling recomputes instantly, client-side.
- Extracted the AA/AAA radiogroup markup (previously only in `ContrastFixSuggester`) into a shared `TargetLevelToggle` component so the fix-suggester's existing local per-suggestion toggle and this new global one render identically instead of diverging. `ContrastFixSuggester` now imports the shared `TargetLevel` type from `src/lib/types` instead of declaring its own.
- `TARGET_LEVELS` moved to `src/lib/constants.ts` as the single source of truth.

**Touch-target detection has the same AA/AAA gap** (`MIN_TOUCH_TARGET_SIZE` is hardcoded to the AAA-level 44px threshold, with no way to check the AA-level 24px minimum) but isn't addressed here. Unlike contrast, that threshold is baked into the scan itself rather than a display-time filter, so making it toggle instantly needs a separate, bigger change to the scan loop - tracked as a deliberate follow-up, not an oversight.

## Test plan
- [x] New tests: `contrastFailsTargetLevel` (`src/lib/utils/index.test.ts`), `useIssuesStore.getIssueGroupList`/`setTargetLevel` AA/AAA behaviour, `TargetLevelToggle` component, `IssuesOverviewList`'s toggle visibility + live recompute
- [x] `npm run test` (214/214), `npm run lint`, `tsc -b`, `npm run build` all clean
- [x] Mutation-tested the three new pieces of logic (`contrastFailsTargetLevel`'s AAA branch, the store's default target level, `IssuesOverviewList`'s toggle-visibility guard) by breaking each and confirming the relevant test failed, then restored
- [ ] Manual Figma dev-mode check of the toggle's visual placement/spacing (pure UI/store logic, no `figma`-runtime code touched, so not required for correctness - but worth a look before merging)