### PR TITLE
perf: replace O(n^2) touch-target spacing check with a spatial index

### DIFF
--- a/plugin/code.ts
+++ b/plugin/code.ts
@@ -1,41 +1,39 @@
 /// <reference types="@figma/plugin-typings" />
 
-import {
-  convertHexColorToRgbColor,
-  isLocked,
-  isVisible,
-} from "@create-figma-plugin/utilities";
+import { convertHexColorToRgbColor, isLocked, isVisible } from "@create-figma-plugin/utilities";
 import { RGBColor } from "wcag-contrast";
 
 import {
-  MESSAGE_TYPES,
-  MIN_FONT_SIZE,
-  SCAN_SETTINGS_STORAGE_KEY,
-  TOUCH_TARGET_MIN_SIZE,
+	MESSAGE_TYPES,
+	MIN_FONT_SIZE,
+	SCAN_SETTINGS_STORAGE_KEY,
+	TOUCH_TARGET_MIN_SIZE,
 } from "@/lib/constants";
 import {
-  analyzeTextNodeForContrastIssue,
-  createTouchTargetIssue,
-  createTypographyIssue,
-  isTouchTarget,
-  isTouchTargetTooClose,
-  isTouchTargetTooSmall,
-  postMessageToUI,
-  replaceTopmostVisibleSolidFillColor,
+	analyzeTextNodeForContrastIssue,
+	buildTouchTargetSpatialIndex,
+	createTouchTargetIssue,
+	createTypographyIssue,
+	getNearbyNodes,
+	isTouchTarget,
+	isTouchTargetTooClose,
+	isTouchTargetTooSmall,
+	postMessageToUI,
+	replaceTopmostVisibleSolidFillColor,
 } from "@/lib/figmaUtils";
 import generateAltTextForLayer from "@/lib/helpers/generateAltTextForLayer";
 import { DeviceType, IssueX, TargetLevel } from "@/lib/types";
 import {
-  figmaRGBtoHex,
-  getIsQuickCheckModeActive,
-  getScanSettings,
-  setIsQuickCheckModeActive,
-  setScanSettings,
+	figmaRGBtoHex,
+	getIsQuickCheckModeActive,
+	getScanSettings,
+	setIsQuickCheckModeActive,
+	setScanSettings,
 } from "@/lib/utils";
 
 type ScanSettings = {
-  deviceType?: DeviceType;
-  targetLevel?: TargetLevel;
+	deviceType?: DeviceType;
+	targetLevel?: TargetLevel;
 };
 
 figma.showUI(__html__);
@@ -46,328 +44,313 @@ figma.ui.resize(375, 550);
 // unlike the in-memory Zustand store the UI iframe gets recreated with
 // every time the plugin reopens.
 (async () => {
-  const stored = (await figma.clientStorage.getAsync(
-    SCAN_SETTINGS_STORAGE_KEY,
-  )) as { deviceType?: DeviceType; targetLevel?: TargetLevel } | undefined;
+	const stored = (await figma.clientStorage.getAsync(SCAN_SETTINGS_STORAGE_KEY)) as
+		{ deviceType?: DeviceType; targetLevel?: TargetLevel } | undefined;
 
-  const settings = {
-    deviceType: stored?.deviceType ?? "touch",
-    targetLevel: stored?.targetLevel ?? "AA",
-  };
+	const settings = {
+		deviceType: stored?.deviceType ?? "touch",
+		targetLevel: stored?.targetLevel ?? "AA",
+	};
 
-  setScanSettings(settings);
-  postMessageToUI(MESSAGE_TYPES.LOAD_SCAN_SETTINGS, settings);
+	setScanSettings(settings);
+	postMessageToUI(MESSAGE_TYPES.LOAD_SCAN_SETTINGS, settings);
 })();
 
 figma.ui.onmessage = async (message) => {
-  try {
-    switch (message.type) {
-      case MESSAGE_TYPES.START_QUICKCHECK:
-        handleStartQuickCheck(message);
-        break;
+	try {
+		switch (message.type) {
+			case MESSAGE_TYPES.START_QUICKCHECK:
+				handleStartQuickCheck(message);
+				break;
 
-      case MESSAGE_TYPES.CANCEL_QUICKCHECK:
-        handleCancelQuickCheck();
-        break;
+			case MESSAGE_TYPES.CANCEL_QUICKCHECK:
+				handleCancelQuickCheck();
+				break;
 
-      case MESSAGE_TYPES.SCAN:
-        await handleScan(message);
-        break;
+			case MESSAGE_TYPES.SCAN:
+				await handleScan(message);
+				break;
 
-      case MESSAGE_TYPES.SAVE_SCAN_SETTINGS:
-        await handleSaveScanSettings(message);
-        break;
+			case MESSAGE_TYPES.SAVE_SCAN_SETTINGS:
+				await handleSaveScanSettings(message);
+				break;
 
-      case MESSAGE_TYPES.UPDATE_FONT_SIZE:
-        await handleUpdateFontSize(message);
-        break;
+			case MESSAGE_TYPES.UPDATE_FONT_SIZE:
+				await handleUpdateFontSize(message);
+				break;
 
-      case MESSAGE_TYPES.UPDATE_FILL_COLOR:
-        await handleUpdateFillColor(message);
-        break;
+			case MESSAGE_TYPES.UPDATE_FILL_COLOR:
+				await handleUpdateFillColor(message);
+				break;
 
-      case MESSAGE_TYPES.NAVIGATE:
-        await handleNavigate(message);
-        break;
+			case MESSAGE_TYPES.NAVIGATE:
+				await handleNavigate(message);
+				break;
 
-      case MESSAGE_TYPES.GET_IMAGE_DATA:
-        await generateAltTextForLayer();
-        break;
+			case MESSAGE_TYPES.GET_IMAGE_DATA:
+				await generateAltTextForLayer();
+				break;
 
-      case MESSAGE_TYPES.NOTIFY:
-        handleNotify(message);
-        break;
+			case MESSAGE_TYPES.NOTIFY:
+				handleNotify(message);
+				break;
 
-      default:
-        console.warn(
-          `Unhandled request. Message type does not exist: ${message.type}`,
-        );
-    }
-  } catch (error) {
-    figma.notify("An error occurred while executing task.");
-    console.error("Error in onmessage handler:", error);
-  }
+			default:
+				console.warn(`Unhandled request. Message type does not exist: ${message.type}`);
+		}
+	} catch (error) {
+		figma.notify("An error occurred while executing task.");
+		console.error("Error in onmessage handler:", error);
+	}
 };
 
 figma.on("selectionchange", async () => {
-  const isQuickCheckModeActive = getIsQuickCheckModeActive();
-  if (!isQuickCheckModeActive) return;
+	const isQuickCheckModeActive = getIsQuickCheckModeActive();
+	if (!isQuickCheckModeActive) return;
 
-  const selection = figma.currentPage.selection;
+	const selection = figma.currentPage.selection;
 
-  if (selection.length === 0) {
-    postMessageToUI(MESSAGE_TYPES.NO_SELECTION, true);
-    return;
-  }
+	if (selection.length === 0) {
+		postMessageToUI(MESSAGE_TYPES.NO_SELECTION, true);
+		return;
+	}
 
-  if (selection.length > 0) {
-    postMessageToUI(MESSAGE_TYPES.LAYER_SELECTED, true);
-  }
+	if (selection.length > 0) {
+		postMessageToUI(MESSAGE_TYPES.LAYER_SELECTED, true);
+	}
 
-  try {
-    const { deviceType, targetLevel } = getScanSettings();
-    const detectedIssues = await detectIssuesInSelection(
-      selection,
-      deviceType,
-      targetLevel,
-    );
-    if (detectedIssues.length) {
-      postMessageToUI(MESSAGE_TYPES.DETECTED_ISSUE, detectedIssues);
-    }
-  } catch (error) {
-    console.error("Error in selectionchange handler:", error);
-  }
+	try {
+		const { deviceType, targetLevel } = getScanSettings();
+		const detectedIssues = await detectIssuesInSelection(selection, deviceType, targetLevel);
+		if (detectedIssues.length) {
+			postMessageToUI(MESSAGE_TYPES.DETECTED_ISSUE, detectedIssues);
+		}
+	} catch (error) {
+		console.error("Error in selectionchange handler:", error);
+	}
 });
 
 async function handleStartQuickCheck(message: ScanSettings) {
-  const deviceType = message.deviceType ?? "touch";
-  const targetLevel = message.targetLevel ?? "AA";
-  setScanSettings({ deviceType, targetLevel });
-  setIsQuickCheckModeActive(true);
+	const deviceType = message.deviceType ?? "touch";
+	const targetLevel = message.targetLevel ?? "AA";
+	setScanSettings({ deviceType, targetLevel });
+	setIsQuickCheckModeActive(true);
 
-  postMessageToUI(MESSAGE_TYPES.QUICKCHECK_ACTIVE, getIsQuickCheckModeActive());
+	postMessageToUI(MESSAGE_TYPES.QUICKCHECK_ACTIVE, getIsQuickCheckModeActive());
 
-  const selection = figma.currentPage.selection;
+	const selection = figma.currentPage.selection;
 
-  if (selection.length === 0) {
-    postMessageToUI(MESSAGE_TYPES.NO_SELECTION, true);
-    return;
-  }
+	if (selection.length === 0) {
+		postMessageToUI(MESSAGE_TYPES.NO_SELECTION, true);
+		return;
+	}
 
-  try {
-    const detectedIssues = await detectIssuesInSelection(
-      selection,
-      deviceType,
-      targetLevel,
-    );
-    if (detectedIssues.length) {
-      postMessageToUI(MESSAGE_TYPES.DETECTED_ISSUE, detectedIssues);
-    }
-  } catch (error) {
-    console.error("Error in selectionchange handler:", error);
-  }
+	try {
+		const detectedIssues = await detectIssuesInSelection(selection, deviceType, targetLevel);
+		if (detectedIssues.length) {
+			postMessageToUI(MESSAGE_TYPES.DETECTED_ISSUE, detectedIssues);
+		}
+	} catch (error) {
+		console.error("Error in selectionchange handler:", error);
+	}
 }
 
 function handleCancelQuickCheck() {
-  setIsQuickCheckModeActive(false);
+	setIsQuickCheckModeActive(false);
 }
 
 function isScannable(node: SceneNode): boolean {
-  return isVisible(node) && !isLocked(node);
+	return isVisible(node) && !isLocked(node);
 }
 
 async function handleScan(message: ScanSettings) {
-  const deviceType = message.deviceType ?? "touch";
-  const targetLevel = message.targetLevel ?? "AA";
-  setScanSettings({ deviceType, targetLevel });
+	const deviceType = message.deviceType ?? "touch";
+	const targetLevel = message.targetLevel ?? "AA";
+	setScanSettings({ deviceType, targetLevel });
 
-  const allTextNodes = figma.currentPage.findAll(
-    (node) => node.type === "TEXT" && isScannable(node),
-  ) as TextNode[];
-  // const allVectorNodes = figma.currentPage.findAll(
-  //   (node) => node.type === "VECTOR",
-  // ) as VectorNode[];
-  const allPageNodes = figma.currentPage.findAll((node) =>
-    isScannable(node),
-  ) as SceneNode[];
+	const allTextNodes = figma.currentPage.findAll(
+		(node) => node.type === "TEXT" && isScannable(node),
+	) as TextNode[];
+	// const allVectorNodes = figma.currentPage.findAll(
+	//   (node) => node.type === "VECTOR",
+	// ) as VectorNode[];
+	const allPageNodes = figma.currentPage.findAll((node) => isScannable(node)) as SceneNode[];
 
-  const issues: IssueX[] = await collectIssues(
-    allTextNodes,
-    allPageNodes,
-    deviceType,
-    targetLevel,
-  );
-  postMessageToUI(MESSAGE_TYPES.LOAD_ISSUES, issues);
+	const issues: IssueX[] = await collectIssues(
+		allTextNodes,
+		allPageNodes,
+		deviceType,
+		targetLevel,
+	);
+	postMessageToUI(MESSAGE_TYPES.LOAD_ISSUES, issues);
 }
 
 async function handleSaveScanSettings(message: ScanSettings) {
-  const deviceType = message.deviceType ?? "touch";
-  const targetLevel = message.targetLevel ?? "AA";
-  setScanSettings({ deviceType, targetLevel });
-  await figma.clientStorage.setAsync(SCAN_SETTINGS_STORAGE_KEY, {
-    deviceType,
-    targetLevel,
-  });
+	const deviceType = message.deviceType ?? "touch";
+	const targetLevel = message.targetLevel ?? "AA";
+	setScanSettings({ deviceType, targetLevel });
+	await figma.clientStorage.setAsync(SCAN_SETTINGS_STORAGE_KEY, {
+		deviceType,
+		targetLevel,
+	});
 }
 
 async function handleUpdateFontSize(message: { id: string; fontSize: number }) {
-  const node = (await figma.getNodeByIdAsync(message.id)) as TextNode | null;
-  if (node && node.type === "TEXT") {
-    await figma.loadFontAsync(node.fontName as FontName);
-    node.fontSize = message.fontSize;
-  } else {
-    console.warn(`Failed to update font size for node ${message.id}`);
-  }
+	const node = (await figma.getNodeByIdAsync(message.id)) as TextNode | null;
+	if (node && node.type === "TEXT") {
+		await figma.loadFontAsync(node.fontName as FontName);
+		node.fontSize = message.fontSize;
+	} else {
+		console.warn(`Failed to update font size for node ${message.id}`);
+	}
 }
 
-async function handleUpdateFillColor(message: {
-  nodeId: string;
-  color: RGBColor;
-}) {
-  const node = await figma.getNodeByIdAsync(message.nodeId);
-  if (!node || !("fills" in node) || !Array.isArray(node.fills)) {
-    console.warn(`Failed to update fill color for node ${message.nodeId}`);
-    return;
-  }
+async function handleUpdateFillColor(message: { nodeId: string; color: RGBColor }) {
+	const node = await figma.getNodeByIdAsync(message.nodeId);
+	if (!node || !("fills" in node) || !Array.isArray(node.fills)) {
+		console.warn(`Failed to update fill color for node ${message.nodeId}`);
+		return;
+	}
 
-  const figmaColor = convertHexColorToRgbColor(
-    figmaRGBtoHex(message.color).slice(1),
-  );
-  if (!figmaColor) {
-    console.warn(
-      `Failed to convert suggested color for node ${message.nodeId}`,
-    );
-    return;
-  }
+	const figmaColor = convertHexColorToRgbColor(figmaRGBtoHex(message.color).slice(1));
+	if (!figmaColor) {
+		console.warn(`Failed to convert suggested color for node ${message.nodeId}`);
+		return;
+	}
 
-  const updatedFills = replaceTopmostVisibleSolidFillColor(
-    node.fills as Paint[],
-    figmaColor,
-  );
-  if (!updatedFills) {
-    console.warn(`No visible solid fill found on node ${message.nodeId}`);
-    return;
-  }
+	const updatedFills = replaceTopmostVisibleSolidFillColor(node.fills as Paint[], figmaColor);
+	if (!updatedFills) {
+		console.warn(`No visible solid fill found on node ${message.nodeId}`);
+		return;
+	}
 
-  node.fills = updatedFills;
+	node.fills = updatedFills;
 }
 
 function handleNotify(message: { message: string }) {
-  figma.notify(message.message);
+	figma.notify(message.message);
 }
 
 async function handleNavigate(message: { id: string }) {
-  const node = (await figma.getNodeByIdAsync(message.id)) as SceneNode;
-  if (node) {
-    figma.currentPage.selection = [node];
-    figma.viewport.scrollAndZoomIntoView([node]);
-  } else {
-    console.warn(`Node with ID ${message.id} not found.`);
-  }
+	const node = (await figma.getNodeByIdAsync(message.id)) as SceneNode;
+	if (node) {
+		figma.currentPage.selection = [node];
+		figma.viewport.scrollAndZoomIntoView([node]);
+	} else {
+		console.warn(`Node with ID ${message.id} not found.`);
+	}
 }
 
 async function collectIssues(
-  allTextNodes: TextNode[],
-  allPageNodes: SceneNode[],
-  deviceType: DeviceType,
-  targetLevel: TargetLevel,
+	allTextNodes: TextNode[],
+	allPageNodes: SceneNode[],
+	deviceType: DeviceType,
+	targetLevel: TargetLevel,
 ): Promise<IssueX[]> {
-  const issues: IssueX[] = [];
+	const issues: IssueX[] = [];
 
-  await Promise.all(
-    allTextNodes.map(async (textNode) => {
-      // Safeguard font loading
-      try {
-        if (textNode.fontName === figma.mixed) {
-          return;
-        }
+	await Promise.all(
+		allTextNodes.map(async (textNode) => {
+			// Safeguard font loading
+			try {
+				if (textNode.fontName === figma.mixed) {
+					return;
+				}
 
-        // Ensure fontName is of the correct format
-        const fontName = textNode.fontName as FontName;
-        await figma.loadFontAsync(fontName);
+				// Ensure fontName is of the correct format
+				const fontName = textNode.fontName as FontName;
+				await figma.loadFontAsync(fontName);
 
-        if (
-          typeof textNode.fontSize === "number" &&
-          textNode.fontSize < MIN_FONT_SIZE
-        ) {
-          issues.push(createTypographyIssue(textNode));
-        }
+				if (typeof textNode.fontSize === "number" && textNode.fontSize < MIN_FONT_SIZE) {
+					issues.push(createTypographyIssue(textNode));
+				}
 
-        await analyzeTextNodeForContrastIssue(textNode, issues);
-      } catch (error) {
-        console.error(
-          `Failed to load font for text node "${textNode.name}":`,
-          error,
-        );
-      }
-    }),
-  );
+				await analyzeTextNodeForContrastIssue(textNode, issues);
+			} catch (error) {
+				console.error(`Failed to load font for text node "${textNode.name}":`, error);
+			}
+		}),
+	);
 
-  // Touch target size/spacing (WCAG 2.5.5/2.5.8) exist because of
-  // touch/finger imprecision - there's no equivalent WCAG-mandated minimum
-  // for pointer/mouse-driven interfaces, so this is skipped entirely for
-  // "pointer" designs rather than checked against an invented number.
-  if (deviceType === "touch") {
-    const minSize = TOUCH_TARGET_MIN_SIZE[targetLevel];
-    for (const node of allPageNodes) {
-      if ("absoluteBoundingBox" in node && (await isTouchTarget(node))) {
-        if (isTouchTargetTooSmall(node, minSize)) {
-          const issue = createTouchTargetIssue(node, "Size", minSize);
-          if (issue) {
-            issues.push(issue);
-          }
-        }
-        if (isTouchTargetTooClose(node, allPageNodes)) {
-          const issue = createTouchTargetIssue(node, "Spacing", minSize);
-          if (issue) {
-            issues.push(issue);
-          }
-        }
-      }
-    }
-  }
+	// Touch target size/spacing (WCAG 2.5.5/2.5.8) exist because of
+	// touch/finger imprecision - there's no equivalent WCAG-mandated minimum
+	// for pointer/mouse-driven interfaces, so this is skipped entirely for
+	// "pointer" designs rather than checked against an invented number.
+	if (deviceType === "touch") {
+		const minSize = TOUCH_TARGET_MIN_SIZE[targetLevel];
 
-  return issues;
+		// Building the spatial index and resolving touch-target eligibility are
+		// both independent of the per-node checks below, so they're done as one
+		// upfront pass instead of inline inside a sequential loop - see
+		// buildTouchTargetSpatialIndex/getNearbyNodes (figmaUtils) for why the
+		// naive all-pairs distance check doesn't scale to large pages.
+		const spatialIndex = buildTouchTargetSpatialIndex(allPageNodes);
+		const eligibilityResults = await Promise.all(
+			allPageNodes.map(async (node) => ({
+				node,
+				eligible: "absoluteBoundingBox" in node && (await isTouchTarget(node)),
+			})),
+		);
+
+		for (const { node, eligible } of eligibilityResults) {
+			if (!eligible) continue;
+
+			if (isTouchTargetTooSmall(node, minSize)) {
+				const issue = createTouchTargetIssue(node, "Size", minSize);
+				if (issue) {
+					issues.push(issue);
+				}
+			}
+			if (isTouchTargetTooClose(node, getNearbyNodes(node, spatialIndex))) {
+				const issue = createTouchTargetIssue(node, "Spacing", minSize);
+				if (issue) {
+					issues.push(issue);
+				}
+			}
+		}
+	}
+
+	return issues;
 }
 
 async function detectIssuesInSelection(
-  selectedNodes: readonly SceneNode[],
-  deviceType: DeviceType,
-  targetLevel: TargetLevel,
+	selectedNodes: readonly SceneNode[],
+	deviceType: DeviceType,
+	targetLevel: TargetLevel,
 ): Promise<IssueX[]> {
-  const issues: IssueX[] = [];
-  const minSize = TOUCH_TARGET_MIN_SIZE[targetLevel];
+	const issues: IssueX[] = [];
+	const minSize = TOUCH_TARGET_MIN_SIZE[targetLevel];
 
-  await Promise.all(
-    selectedNodes.map(async (node) => {
-      if (deviceType === "touch") {
-        if (isTouchTargetTooSmall(node, minSize)) {
-          const issue = createTouchTargetIssue(node, "Size", minSize);
-          if (issue) {
-            issues.push(issue);
-          }
-        }
-        if (isTouchTargetTooClose(node, [...figma.currentPage.children])) {
-          const issue = createTouchTargetIssue(node, "Spacing", minSize);
-          if (issue) {
-            issues.push(issue);
-          }
-        }
-      }
+	await Promise.all(
+		selectedNodes.map(async (node) => {
+			if (deviceType === "touch") {
+				if (isTouchTargetTooSmall(node, minSize)) {
+					const issue = createTouchTargetIssue(node, "Size", minSize);
+					if (issue) {
+						issues.push(issue);
+					}
+				}
+				if (isTouchTargetTooClose(node, [...figma.currentPage.children])) {
+					const issue = createTouchTargetIssue(node, "Spacing", minSize);
+					if (issue) {
+						issues.push(issue);
+					}
+				}
+			}
 
-      if (
-        node.type === "TEXT" &&
-        node.fontSize &&
-        typeof node.fontSize === "number" &&
-        node.fontSize < MIN_FONT_SIZE
-      ) {
-        issues.push(createTypographyIssue(node));
-      }
-      if (node.type === "TEXT") {
-        await analyzeTextNodeForContrastIssue(node, issues);
-      }
-    }),
-  );
+			if (
+				node.type === "TEXT" &&
+				node.fontSize &&
+				typeof node.fontSize === "number" &&
+				node.fontSize < MIN_FONT_SIZE
+			) {
+				issues.push(createTypographyIssue(node));
+			}
+			if (node.type === "TEXT") {
+				await analyzeTextNodeForContrastIssue(node, issues);
+			}
+		}),
+	);
 
-  return issues;
+	return issues;
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -35,6 +35,18 @@ export const MIN_TOUCH_TARGET_SPACING: number = 8;
 
 export const TOUCH_TARGET_KEYWORDS = ["btn", "button", "link", "touch"];
 
+/**
+ * Grid cell size (px) for the spatial index isTouchTargetTooClose's callers
+ * use to avoid comparing every scannable node against every other one - see
+ * buildTouchTargetSpatialIndex (figmaUtils). Two nodes can only ever trigger
+ * a spacing violation if they're within MIN_TOUCH_TARGET_SPACING of each
+ * other, so cells only need to be roughly "typical touch target" sized:
+ * big enough that most elements span 1-4 cells (keeping the index cheap to
+ * build), small enough that a busy row of icons doesn't collapse into one
+ * cell and defeat the point.
+ */
+export const TOUCH_TARGET_SPATIAL_CELL_SIZE = 100;
+
 export const TARGET_LEVELS: readonly TargetLevel[] = ["AA", "AAA"] as const;
 
 /**

--- a/src/lib/figmaUtils/index.test.ts
+++ b/src/lib/figmaUtils/index.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 import { MIN_TOUCH_TARGET_SIZE_AAA, TOUCH_TARGET_MIN_SIZE } from "@/lib/constants";
 import solidFill from "@/lib/test-utils/solidFill";
 import {
+	buildTouchTargetSpatialIndex,
 	createContrastIssue,
 	createTouchTargetIssue,
 	createTypographyIssue,
 	extractForegroundColor,
+	getNearbyNodes,
 	isTouchTarget,
 	isTouchTargetTooClose,
 	isTouchTargetTooSmall,
@@ -204,6 +206,125 @@ describe("isTouchTargetTooClose", () => {
 		const other = fakeNode("b", { x: 52, y: 0, width: 44, height: 44 });
 
 		expect(isTouchTargetTooClose(node, [node, other])).toBe(false);
+	});
+});
+
+describe("getNearbyNodes", () => {
+	const node = fakeNode("a", { x: 0, y: 0, width: 44, height: 44 });
+
+	it("returns an empty array when the node has no bounding box", () => {
+		const boundsless = { id: "a" } as unknown as SceneNode;
+		const index = buildTouchTargetSpatialIndex([node]);
+
+		expect(getNearbyNodes(boundsless, index)).toEqual([]);
+	});
+
+	it("finds a node sharing a cell nearby", () => {
+		const other = fakeNode("b", { x: 49, y: 0, width: 44, height: 44 });
+		const index = buildTouchTargetSpatialIndex([node, other]);
+
+		expect(getNearbyNodes(node, index).map((n) => n.id)).toEqual(["b"]);
+	});
+
+	it("excludes nodes far enough away to land in unrelated cells", () => {
+		const far = fakeNode("far", { x: 5000, y: 5000, width: 44, height: 44 });
+		const index = buildTouchTargetSpatialIndex([node, far]);
+
+		expect(getNearbyNodes(node, index)).toEqual([]);
+	});
+
+	it("excludes the node itself even though it shares its own cells", () => {
+		const index = buildTouchTargetSpatialIndex([node]);
+
+		expect(getNearbyNodes(node, index)).toEqual([]);
+	});
+
+	it("does not return duplicates when a large node spans multiple shared cells", () => {
+		const big = fakeNode("big", { x: 0, y: 0, width: 500, height: 500 });
+		const index = buildTouchTargetSpatialIndex([node, big], 100);
+
+		const nearby = getNearbyNodes(node, index, 100);
+		const bigOccurrences = nearby.filter((n) => n.id === "big");
+
+		expect(bigOccurrences).toHaveLength(1);
+	});
+
+	it("skips indexing nodes without a bounding box", () => {
+		const boundsless = { id: "boundsless" } as unknown as SceneNode;
+		const index = buildTouchTargetSpatialIndex([node, boundsless]);
+
+		expect(getNearbyNodes(node, index).some((n) => n.id === "boundsless")).toBe(false);
+	});
+
+	it("agrees with the naive isTouchTargetTooClose result when passed the full node list vs. just the nearby subset", () => {
+		const close = fakeNode("close", { x: 49, y: 0, width: 44, height: 44 });
+		const far = fakeNode("far", { x: 5000, y: 5000, width: 44, height: 44 });
+		const allNodes = [node, close, far];
+		const index = buildTouchTargetSpatialIndex(allNodes);
+
+		expect(isTouchTargetTooClose(node, getNearbyNodes(node, index))).toBe(
+			isTouchTargetTooClose(node, allNodes),
+		);
+	});
+});
+
+describe("spatial index performance", () => {
+	it("finds the same spacing violations as the naive all-pairs check, dramatically faster on a large page", () => {
+		const NODE_COUNT = 4000;
+		const nodes: SceneNode[] = [];
+
+		// Spread nodes across a huge virtual page so most pairs are far apart -
+		// this mirrors a large multi-frame/multi-section design, the scenario
+		// that made the naive O(n^2) isTouchTargetTooClose freeze the plugin.
+		const gridStride = 500;
+		const columns = Math.ceil(Math.sqrt(NODE_COUNT));
+		for (let i = 0; i < NODE_COUNT; i++) {
+			const col = i % columns;
+			const row = Math.floor(i / columns);
+			nodes.push(
+				fakeNode(`n${i}`, {
+					x: col * gridStride,
+					y: row * gridStride,
+					width: 44,
+					height: 44,
+				}),
+			);
+		}
+
+		// Scatter in genuinely close pairs so both approaches still have real
+		// spacing violations to find, not just distant nodes.
+		for (let i = 0; i < 20; i++) {
+			nodes.push(
+				fakeNode(`close-a-${i}`, { x: i * 1000, y: 0, width: 44, height: 44 }),
+				fakeNode(`close-b-${i}`, { x: i * 1000 + 49, y: 0, width: 44, height: 44 }),
+			);
+		}
+
+		const index = buildTouchTargetSpatialIndex(nodes);
+
+		const indexedStart = performance.now();
+		let indexedViolationCount = 0;
+		for (const node of nodes) {
+			if (isTouchTargetTooClose(node, getNearbyNodes(node, index))) indexedViolationCount++;
+		}
+		const indexedDuration = performance.now() - indexedStart;
+
+		const naiveStart = performance.now();
+		let naiveViolationCount = 0;
+		for (const node of nodes) {
+			if (isTouchTargetTooClose(node, nodes)) naiveViolationCount++;
+		}
+		const naiveDuration = performance.now() - naiveStart;
+
+		// The index changes how fast violations are found, not which ones -
+		// same violation count either way.
+		expect(indexedViolationCount).toBe(naiveViolationCount);
+		expect(indexedViolationCount).toBeGreaterThan(0);
+
+		// A generous 3x margin avoids flakiness on slower machines while still
+		// catching a real algorithmic regression (e.g. someone accidentally
+		// widening the cell size enough to defeat the index).
+		expect(indexedDuration).toBeLessThan(naiveDuration / 3);
 	});
 });
 

--- a/src/lib/figmaUtils/index.ts
+++ b/src/lib/figmaUtils/index.ts
@@ -5,6 +5,7 @@ import {
 	MIN_TOUCH_TARGET_SIZE_AAA,
 	MIN_TOUCH_TARGET_SPACING,
 	TOUCH_TARGET_KEYWORDS,
+	TOUCH_TARGET_SPATIAL_CELL_SIZE,
 } from "../constants";
 import {
 	BackgroundColorResult,
@@ -204,6 +205,106 @@ export const isTouchTargetTooClose = (node: SceneNode, allNodes: SceneNode[]): b
 		return false;
 	});
 };
+
+type BoundingBox = { x: number; y: number; width: number; height: number };
+
+/**
+ * Which spatial grid cells a bounding box overlaps, expanded by
+ * MIN_TOUCH_TARGET_SPACING on every side - two nodes can only ever trigger
+ * an isTouchTargetTooClose violation if they're within that distance of
+ * each other, so a node's "interesting" neighbourhood is its own bounds
+ * grown by that amount, not the whole page.
+ */
+function cellKeysForBounds(bounds: BoundingBox, cellSize: number): string[] {
+	const minCellX = Math.floor((bounds.x - MIN_TOUCH_TARGET_SPACING) / cellSize);
+	const maxCellX = Math.floor((bounds.x + bounds.width + MIN_TOUCH_TARGET_SPACING) / cellSize);
+	const minCellY = Math.floor((bounds.y - MIN_TOUCH_TARGET_SPACING) / cellSize);
+	const maxCellY = Math.floor((bounds.y + bounds.height + MIN_TOUCH_TARGET_SPACING) / cellSize);
+
+	const keys: string[] = [];
+	for (let cellX = minCellX; cellX <= maxCellX; cellX++) {
+		for (let cellY = minCellY; cellY <= maxCellY; cellY++) {
+			keys.push(`${cellX},${cellY}`);
+		}
+	}
+	return keys;
+}
+
+export type TouchTargetSpatialIndex = Map<string, SceneNode[]>;
+
+/**
+ * Buckets nodes into a spatial grid so isTouchTargetTooClose only has to
+ * compare a node against nearby candidates instead of every scannable node
+ * on the page. Naive all-pairs comparison is O(n^2) in page node count - a
+ * page with a handful of complex frames/sections easily reaches thousands
+ * of nodes, which turns into millions of bounding-box comparisons and can
+ * freeze the plugin. Building this index is close to O(n): most nodes only
+ * overlap a handful of cells (see TOUCH_TARGET_SPATIAL_CELL_SIZE) - the
+ * exception is a node whose bounds span most of the page (e.g. a full-page
+ * background rectangle), which is inserted into many cells, but that's rare
+ * enough (typically one or two per page) not to change the overall cost.
+ *
+ * @param {SceneNode[]} nodes - The nodes to index (skips any without a bounding box).
+ * @param {number} [cellSize] - Grid cell size in px.
+ * @returns {TouchTargetSpatialIndex} Map from cell key to the nodes overlapping that cell.
+ */
+export function buildTouchTargetSpatialIndex(
+	nodes: SceneNode[],
+	cellSize: number = TOUCH_TARGET_SPATIAL_CELL_SIZE,
+): TouchTargetSpatialIndex {
+	const index: TouchTargetSpatialIndex = new Map();
+
+	for (const node of nodes) {
+		if (!("absoluteBoundingBox" in node) || !node.absoluteBoundingBox) continue;
+
+		for (const key of cellKeysForBounds(node.absoluteBoundingBox, cellSize)) {
+			const bucket = index.get(key);
+			if (bucket) {
+				bucket.push(node);
+			} else {
+				index.set(key, [node]);
+			}
+		}
+	}
+
+	return index;
+}
+
+/**
+ * Returns the nodes sharing at least one spatial grid cell with `node` (see
+ * buildTouchTargetSpatialIndex) - the only nodes isTouchTargetTooClose could
+ * possibly need to compare `node` against, deduplicated and excluding
+ * `node` itself.
+ *
+ * @param {SceneNode} node - The node to find neighbours for.
+ * @param {TouchTargetSpatialIndex} index - An index built by buildTouchTargetSpatialIndex.
+ * @param {number} [cellSize] - Must match the cellSize the index was built with.
+ * @returns {SceneNode[]} Nearby nodes, or an empty array if `node` has no bounding box.
+ */
+export function getNearbyNodes(
+	node: SceneNode,
+	index: TouchTargetSpatialIndex,
+	cellSize: number = TOUCH_TARGET_SPATIAL_CELL_SIZE,
+): SceneNode[] {
+	if (!("absoluteBoundingBox" in node) || !node.absoluteBoundingBox) return [];
+
+	const seen = new Set<string>([node.id]);
+	const nearby: SceneNode[] = [];
+
+	for (const key of cellKeysForBounds(node.absoluteBoundingBox, cellSize)) {
+		const bucket = index.get(key);
+		if (!bucket) continue;
+
+		for (const candidate of bucket) {
+			if (!seen.has(candidate.id)) {
+				seen.add(candidate.id);
+				nearby.push(candidate);
+			}
+		}
+	}
+
+	return nearby;
+}
 
 /**
  * Creates a touch target issue object for the given node.


### PR DESCRIPTION
## Summary
- Full-page scans of large, multi-frame/multi-section designs could freeze the plugin: `isTouchTargetTooClose` compared every scannable node against every other scannable node in a sequential loop, making the spacing check O(n^2) in page node count.
- Adds `buildTouchTargetSpatialIndex`/`getNearbyNodes` (`src/lib/figmaUtils`), bucketing nodes into a grid keyed by `MIN_TOUCH_TARGET_SPACING`-expanded cells so each node only compares against nodes sharing a cell instead of the whole page.
- `plugin/code.ts`'s `collectIssues` now builds the index once, resolves touch-target eligibility in parallel (`Promise.all`, matching the existing text-node loop's pattern), and looks up nearby candidates instead of scanning `allPageNodes` per node.
- `isTouchTargetTooClose` itself is unchanged — only what callers pass as its candidate list changes, so existing spacing-detection behaviour is preserved.

## Test plan
- [x] New unit tests for `buildTouchTargetSpatialIndex`/`getNearbyNodes` (no bounding box, same-cell match, far-away exclusion, self-exclusion, dedup across multi-cell nodes, boundsless nodes skipped)
- [x] Synthetic 4,000-node benchmark test confirms both approaches find identical violations, and the indexed approach is dramatically faster (35x in this run) than the naive all-pairs comparison
- [x] Mutation-tested the new logic (broke self-exclusion, confirmed 3 tests failed, restored)
- [x] `tsc -b`, `npm run lint`, `npm run test` (260 passing), `npm run build` all clean
- [x] Manually verified in Figma dev mode against the heavy multi-frame file that was previously freezing