### PR TITLE
refactor: extract scan/collection logic out of plugin/code.ts

### DIFF
--- a/plugin/code.ts
+++ b/plugin/code.ts
@@ -1,26 +1,15 @@
 /// <reference types="@figma/plugin-typings" />
 
-import { convertHexColorToRgbColor, isLocked, isVisible } from "@create-figma-plugin/utilities";
+import { convertHexColorToRgbColor } from "@create-figma-plugin/utilities";
 import { RGBColor } from "wcag-contrast";
 
+import { MESSAGE_TYPES, SCAN_SETTINGS_STORAGE_KEY } from "@/lib/constants";
+import { postMessageToUI, replaceTopmostVisibleSolidFillColor } from "@/lib/figmaUtils";
 import {
-	MESSAGE_TYPES,
-	MIN_FONT_SIZE,
-	SCAN_SETTINGS_STORAGE_KEY,
-	TOUCH_TARGET_MIN_SIZE,
-} from "@/lib/constants";
-import {
-	analyzeTextNodeForContrastIssue,
-	buildTouchTargetSpatialIndex,
-	createTouchTargetIssue,
-	createTypographyIssue,
-	getNearbyNodes,
-	isTouchTarget,
-	isTouchTargetTooClose,
-	isTouchTargetTooSmall,
-	postMessageToUI,
-	replaceTopmostVisibleSolidFillColor,
-} from "@/lib/figmaUtils";
+	collectIssues,
+	detectIssuesInSelection,
+	isScannable,
+} from "@/lib/figmaUtils/collectIssues";
 import generateAltTextForLayer from "@/lib/helpers/generateAltTextForLayer";
 import { DeviceType, IssueX, TargetLevel } from "@/lib/types";
 import {
@@ -121,7 +110,9 @@ figma.on("selectionchange", async () => {
 
 	try {
 		const { deviceType, targetLevel } = getScanSettings();
-		const detectedIssues = await detectIssuesInSelection(selection, deviceType, targetLevel);
+		const detectedIssues = await detectIssuesInSelection(selection, deviceType, targetLevel, [
+			...figma.currentPage.children,
+		]);
 		if (detectedIssues.length) {
 			postMessageToUI(MESSAGE_TYPES.DETECTED_ISSUE, detectedIssues);
 		}
@@ -146,7 +137,9 @@ async function handleStartQuickCheck(message: ScanSettings) {
 	}
 
 	try {
-		const detectedIssues = await detectIssuesInSelection(selection, deviceType, targetLevel);
+		const detectedIssues = await detectIssuesInSelection(selection, deviceType, targetLevel, [
+			...figma.currentPage.children,
+		]);
 		if (detectedIssues.length) {
 			postMessageToUI(MESSAGE_TYPES.DETECTED_ISSUE, detectedIssues);
 		}
@@ -157,10 +150,6 @@ async function handleStartQuickCheck(message: ScanSettings) {
 
 function handleCancelQuickCheck() {
 	setIsQuickCheckModeActive(false);
-}
-
-function isScannable(node: SceneNode): boolean {
-	return isVisible(node) && !isLocked(node);
 }
 
 async function handleScan(message: ScanSettings) {
@@ -239,118 +228,4 @@ async function handleNavigate(message: { id: string }) {
 	} else {
 		console.warn(`Node with ID ${message.id} not found.`);
 	}
-}
-
-async function collectIssues(
-	allTextNodes: TextNode[],
-	allPageNodes: SceneNode[],
-	deviceType: DeviceType,
-	targetLevel: TargetLevel,
-): Promise<IssueX[]> {
-	const issues: IssueX[] = [];
-
-	await Promise.all(
-		allTextNodes.map(async (textNode) => {
-			// Safeguard font loading
-			try {
-				if (textNode.fontName === figma.mixed) {
-					return;
-				}
-
-				// Ensure fontName is of the correct format
-				const fontName = textNode.fontName as FontName;
-				await figma.loadFontAsync(fontName);
-
-				if (typeof textNode.fontSize === "number" && textNode.fontSize < MIN_FONT_SIZE) {
-					issues.push(createTypographyIssue(textNode));
-				}
-
-				await analyzeTextNodeForContrastIssue(textNode, issues);
-			} catch (error) {
-				console.error(`Failed to load font for text node "${textNode.name}":`, error);
-			}
-		}),
-	);
-
-	// Touch target size/spacing (WCAG 2.5.5/2.5.8) exist because of
-	// touch/finger imprecision - there's no equivalent WCAG-mandated minimum
-	// for pointer/mouse-driven interfaces, so this is skipped entirely for
-	// "pointer" designs rather than checked against an invented number.
-	if (deviceType === "touch") {
-		const minSize = TOUCH_TARGET_MIN_SIZE[targetLevel];
-
-		// Building the spatial index and resolving touch-target eligibility are
-		// both independent of the per-node checks below, so they're done as one
-		// upfront pass instead of inline inside a sequential loop - see
-		// buildTouchTargetSpatialIndex/getNearbyNodes (figmaUtils) for why the
-		// naive all-pairs distance check doesn't scale to large pages.
-		const spatialIndex = buildTouchTargetSpatialIndex(allPageNodes);
-		const eligibilityResults = await Promise.all(
-			allPageNodes.map(async (node) => ({
-				node,
-				eligible: "absoluteBoundingBox" in node && (await isTouchTarget(node)),
-			})),
-		);
-
-		for (const { node, eligible } of eligibilityResults) {
-			if (!eligible) continue;
-
-			if (isTouchTargetTooSmall(node, minSize)) {
-				const issue = createTouchTargetIssue(node, "Size", minSize);
-				if (issue) {
-					issues.push(issue);
-				}
-			}
-			if (isTouchTargetTooClose(node, getNearbyNodes(node, spatialIndex))) {
-				const issue = createTouchTargetIssue(node, "Spacing", minSize);
-				if (issue) {
-					issues.push(issue);
-				}
-			}
-		}
-	}
-
-	return issues;
-}
-
-async function detectIssuesInSelection(
-	selectedNodes: readonly SceneNode[],
-	deviceType: DeviceType,
-	targetLevel: TargetLevel,
-): Promise<IssueX[]> {
-	const issues: IssueX[] = [];
-	const minSize = TOUCH_TARGET_MIN_SIZE[targetLevel];
-
-	await Promise.all(
-		selectedNodes.map(async (node) => {
-			if (deviceType === "touch") {
-				if (isTouchTargetTooSmall(node, minSize)) {
-					const issue = createTouchTargetIssue(node, "Size", minSize);
-					if (issue) {
-						issues.push(issue);
-					}
-				}
-				if (isTouchTargetTooClose(node, [...figma.currentPage.children])) {
-					const issue = createTouchTargetIssue(node, "Spacing", minSize);
-					if (issue) {
-						issues.push(issue);
-					}
-				}
-			}
-
-			if (
-				node.type === "TEXT" &&
-				node.fontSize &&
-				typeof node.fontSize === "number" &&
-				node.fontSize < MIN_FONT_SIZE
-			) {
-				issues.push(createTypographyIssue(node));
-			}
-			if (node.type === "TEXT") {
-				await analyzeTextNodeForContrastIssue(node, issues);
-			}
-		}),
-	);
-
-	return issues;
 }

--- a/src/lib/figmaUtils/collectIssues/index.test.ts
+++ b/src/lib/figmaUtils/collectIssues/index.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { MIN_TOUCH_TARGET_SIZE_AA, MIN_TOUCH_TARGET_SIZE_AAA } from "@/lib/constants";
+import fakeSceneNode from "@/lib/test-utils/fakeSceneNode";
+import {
+	collectIssues,
+	collectTouchTargetIssues,
+	detectIssuesInSelection,
+	isScannable,
+} from "./index";
+
+function fakeTouchTargetNode(
+	id: string,
+	bounds: { x: number; y: number; width: number; height: number },
+	name = "Button",
+): SceneNode {
+	return fakeSceneNode(id, bounds, { name });
+}
+
+describe("isScannable", () => {
+	it("returns true for a visible, unlocked node", () => {
+		const node = { visible: true, locked: false, parent: null } as unknown as SceneNode;
+
+		expect(isScannable(node)).toBe(true);
+	});
+
+	it("returns false for a hidden node", () => {
+		const node = { visible: false, locked: false, parent: null } as unknown as SceneNode;
+
+		expect(isScannable(node)).toBe(false);
+	});
+
+	it("returns false for a locked node", () => {
+		const node = { visible: true, locked: true, parent: null } as unknown as SceneNode;
+
+		expect(isScannable(node)).toBe(false);
+	});
+});
+
+describe("collectTouchTargetIssues", () => {
+	it("flags an eligible node smaller than the given target level's minimum", async () => {
+		const node = fakeTouchTargetNode("btn", { x: 0, y: 0, width: 20, height: 20 });
+
+		const issues = await collectTouchTargetIssues([node], "AAA");
+
+		expect(issues).toHaveLength(1);
+		expect(issues[0].type).toBe("TOUCH_TARGET_SIZE");
+		expect(issues[0].nodeData.requiredSizePx).toBe(MIN_TOUCH_TARGET_SIZE_AAA);
+	});
+
+	it("does not flag an ineligible node even when it's too small", async () => {
+		const node = fakeTouchTargetNode(
+			"bg",
+			{ x: 0, y: 0, width: 20, height: 20 },
+			"Background rectangle",
+		);
+
+		const issues = await collectTouchTargetIssues([node], "AAA");
+
+		expect(issues).toHaveLength(0);
+	});
+
+	it("flags spacing violations between two eligible nodes closer than the minimum spacing", async () => {
+		const nodeA = fakeTouchTargetNode("a", { x: 0, y: 0, width: 44, height: 44 });
+		const nodeB = fakeTouchTargetNode("b", { x: 49, y: 0, width: 44, height: 44 });
+
+		const issues = await collectTouchTargetIssues([nodeA, nodeB], "AAA");
+
+		const spacingIssues = issues.filter((issue) => issue.type === "TOUCH_TARGET_SPACING");
+		expect(spacingIssues).toHaveLength(2);
+	});
+
+	it("does not flag spacing for eligible nodes far enough apart", async () => {
+		const nodeA = fakeTouchTargetNode("a", { x: 0, y: 0, width: 44, height: 44 });
+		const nodeB = fakeTouchTargetNode("b", { x: 5000, y: 5000, width: 44, height: 44 });
+
+		const issues = await collectTouchTargetIssues([nodeA, nodeB], "AAA");
+
+		expect(issues.filter((issue) => issue.type === "TOUCH_TARGET_SPACING")).toHaveLength(0);
+	});
+
+	it("uses the AA minimum instead of AAA when given targetLevel AA", async () => {
+		const node = fakeTouchTargetNode("btn", { x: 0, y: 0, width: 30, height: 30 });
+
+		const aaaIssues = await collectTouchTargetIssues([node], "AAA");
+		const aaIssues = await collectTouchTargetIssues([node], "AA");
+
+		expect(aaaIssues.some((issue) => issue.type === "TOUCH_TARGET_SIZE")).toBe(true);
+		expect(aaIssues.some((issue) => issue.type === "TOUCH_TARGET_SIZE")).toBe(false);
+		expect(MIN_TOUCH_TARGET_SIZE_AA).toBe(24);
+	});
+});
+
+describe("collectIssues", () => {
+	it("skips figma.loadFontAsync entirely and still runs touch-target checks when allTextNodes is empty", async () => {
+		const node = fakeTouchTargetNode("btn", { x: 0, y: 0, width: 20, height: 20 });
+
+		const issues = await collectIssues([], [node], "touch", "AAA");
+
+		expect(issues).toHaveLength(1);
+		expect(issues[0].type).toBe("TOUCH_TARGET_SIZE");
+	});
+
+	it("skips touch-target checks entirely for pointer device type", async () => {
+		const node = fakeTouchTargetNode("btn", { x: 0, y: 0, width: 20, height: 20 });
+
+		const issues = await collectIssues([], [node], "pointer", "AAA");
+
+		expect(issues).toHaveLength(0);
+	});
+});
+
+describe("detectIssuesInSelection", () => {
+	it("flags a too-small selected node using the given target level", async () => {
+		const node = fakeTouchTargetNode("btn", { x: 0, y: 0, width: 20, height: 20 });
+
+		const issues = await detectIssuesInSelection([node], "touch", "AAA", []);
+
+		expect(issues.some((issue) => issue.type === "TOUCH_TARGET_SIZE")).toBe(true);
+	});
+
+	it("checks spacing against the given candidate pool, not the selection itself", async () => {
+		const node = fakeTouchTargetNode("btn", { x: 0, y: 0, width: 44, height: 44 });
+		const candidate = fakeTouchTargetNode("neighbour", { x: 49, y: 0, width: 44, height: 44 });
+
+		const withCandidate = await detectIssuesInSelection([node], "touch", "AAA", [
+			node,
+			candidate,
+		]);
+		const withoutCandidate = await detectIssuesInSelection([node], "touch", "AAA", [node]);
+
+		expect(withCandidate.some((issue) => issue.type === "TOUCH_TARGET_SPACING")).toBe(true);
+		expect(withoutCandidate.some((issue) => issue.type === "TOUCH_TARGET_SPACING")).toBe(false);
+	});
+
+	it("skips touch-target checks entirely for pointer device type", async () => {
+		const node = fakeTouchTargetNode("btn", { x: 0, y: 0, width: 20, height: 20 });
+
+		const issues = await detectIssuesInSelection([node], "pointer", "AAA", []);
+
+		expect(issues).toHaveLength(0);
+	});
+
+	it("does not evaluate typography/contrast for a non-TEXT node", async () => {
+		const node = fakeTouchTargetNode("btn", { x: 0, y: 0, width: 44, height: 44 }, "Icon only");
+
+		const issues = await detectIssuesInSelection([node], "pointer", "AAA", []);
+
+		expect(
+			issues.some((issue) => issue.type === "TYPOGRAPHY" || issue.type === "CONTRAST"),
+		).toBe(false);
+	});
+});

--- a/src/lib/figmaUtils/collectIssues/index.ts
+++ b/src/lib/figmaUtils/collectIssues/index.ts
@@ -1,0 +1,183 @@
+import { isLocked, isVisible } from "@create-figma-plugin/utilities";
+import { MIN_FONT_SIZE, TOUCH_TARGET_MIN_SIZE } from "@/lib/constants";
+import { DeviceType, IssueX, TargetLevel } from "@/lib/types";
+import {
+	analyzeTextNodeForContrastIssue,
+	buildTouchTargetSpatialIndex,
+	createTouchTargetIssue,
+	createTypographyIssue,
+	getNearbyNodes,
+	isTouchTarget,
+	isTouchTargetTooClose,
+	isTouchTargetTooSmall,
+} from "../index";
+
+/**
+ * Whether a node should be considered during a scan at all - hidden or
+ * locked layers are skipped regardless of issue type.
+ */
+export function isScannable(node: SceneNode): boolean {
+	return isVisible(node) && !isLocked(node);
+}
+
+/**
+ * Touch target size/spacing (WCAG 2.5.5/2.5.8) checks for every eligible
+ * node in `allPageNodes`. Assumes the caller has already gated this on
+ * `deviceType === "touch"` - WCAG defines no separate desktop threshold, so
+ * there's nothing meaningful to check for "pointer" designs.
+ *
+ * No direct `figma.*` references - `isTouchTarget`'s only async call is
+ * `node.getMainComponentAsync()`, a method on the node itself, so this is
+ * fully unit-testable with plain fake `SceneNode` objects.
+ */
+export async function collectTouchTargetIssues(
+	allPageNodes: SceneNode[],
+	targetLevel: TargetLevel,
+): Promise<IssueX[]> {
+	const issues: IssueX[] = [];
+	const minSize = TOUCH_TARGET_MIN_SIZE[targetLevel];
+
+	// Building the spatial index and resolving touch-target eligibility are
+	// both independent of the per-node checks below, so they're done as one
+	// upfront pass instead of inline inside a sequential loop - see
+	// buildTouchTargetSpatialIndex/getNearbyNodes (figmaUtils) for why the
+	// naive all-pairs distance check doesn't scale to large pages.
+	const spatialIndex = buildTouchTargetSpatialIndex(allPageNodes);
+	const eligibilityResults = await Promise.all(
+		allPageNodes.map(async (node) => ({
+			node,
+			eligible: "absoluteBoundingBox" in node && (await isTouchTarget(node)),
+		})),
+	);
+
+	for (const { node, eligible } of eligibilityResults) {
+		if (!eligible) continue;
+
+		if (isTouchTargetTooSmall(node, minSize)) {
+			const issue = createTouchTargetIssue(node, "Size", minSize);
+			if (issue) {
+				issues.push(issue);
+			}
+		}
+		if (isTouchTargetTooClose(node, getNearbyNodes(node, spatialIndex))) {
+			const issue = createTouchTargetIssue(node, "Spacing", minSize);
+			if (issue) {
+				issues.push(issue);
+			}
+		}
+	}
+
+	return issues;
+}
+
+/**
+ * Typography (WCAG 1.4.4-adjacent min font size) and contrast (1.4.3/1.4.6)
+ * checks for every text node in `allTextNodes`. Genuinely Figma-runtime-only
+ * - `figma.loadFontAsync`/`figma.mixed` (via `analyzeTextNodeForContrastIssue`)
+ * have no vitest equivalent, so this needs manual verification in Figma dev
+ * mode rather than unit tests.
+ */
+async function collectTextNodeIssues(allTextNodes: TextNode[]): Promise<IssueX[]> {
+	const issues: IssueX[] = [];
+
+	await Promise.all(
+		allTextNodes.map(async (textNode) => {
+			// Safeguard font loading
+			try {
+				if (textNode.fontName === figma.mixed) {
+					return;
+				}
+
+				// Ensure fontName is of the correct format
+				const fontName = textNode.fontName as FontName;
+				await figma.loadFontAsync(fontName);
+
+				if (typeof textNode.fontSize === "number" && textNode.fontSize < MIN_FONT_SIZE) {
+					issues.push(createTypographyIssue(textNode));
+				}
+
+				await analyzeTextNodeForContrastIssue(textNode, issues);
+			} catch (error) {
+				console.error(`Failed to load font for text node "${textNode.name}":`, error);
+			}
+		}),
+	);
+
+	return issues;
+}
+
+/**
+ * Full-page-scan orchestrator: combines the text-node checks with the
+ * touch-target checks (skipped entirely for "pointer" designs, since WCAG
+ * defines no separate desktop threshold for 2.5.5/2.5.8 - they exist because
+ * of touch/finger imprecision specifically).
+ *
+ * Callable with `allTextNodes: []` without touching the `figma` global at
+ * all (`Promise.all([])` resolves trivially) - that's what lets the
+ * `deviceType`/touch-target wiring below be integration-tested without a
+ * `figma` mock.
+ */
+export async function collectIssues(
+	allTextNodes: TextNode[],
+	allPageNodes: SceneNode[],
+	deviceType: DeviceType,
+	targetLevel: TargetLevel,
+): Promise<IssueX[]> {
+	const [textNodeIssues, touchTargetIssues] = await Promise.all([
+		collectTextNodeIssues(allTextNodes),
+		deviceType === "touch" ? collectTouchTargetIssues(allPageNodes, targetLevel) : [],
+	]);
+
+	return [...textNodeIssues, ...touchTargetIssues];
+}
+
+/**
+ * Selection-scoped scan (used by quick-check mode): same checks as
+ * `collectIssues`, but only against the nodes actually selected.
+ * `candidateNodesForSpacing` is the pool touch-target spacing is checked
+ * against - passed in explicitly (callers use `figma.currentPage.children`)
+ * instead of read from `figma.currentPage` internally, so this function has
+ * no direct `figma.*` references itself.
+ */
+export async function detectIssuesInSelection(
+	selectedNodes: readonly SceneNode[],
+	deviceType: DeviceType,
+	targetLevel: TargetLevel,
+	candidateNodesForSpacing: SceneNode[],
+): Promise<IssueX[]> {
+	const issues: IssueX[] = [];
+	const minSize = TOUCH_TARGET_MIN_SIZE[targetLevel];
+
+	await Promise.all(
+		selectedNodes.map(async (node) => {
+			if (deviceType === "touch") {
+				if (isTouchTargetTooSmall(node, minSize)) {
+					const issue = createTouchTargetIssue(node, "Size", minSize);
+					if (issue) {
+						issues.push(issue);
+					}
+				}
+				if (isTouchTargetTooClose(node, candidateNodesForSpacing)) {
+					const issue = createTouchTargetIssue(node, "Spacing", minSize);
+					if (issue) {
+						issues.push(issue);
+					}
+				}
+			}
+
+			if (
+				node.type === "TEXT" &&
+				node.fontSize &&
+				typeof node.fontSize === "number" &&
+				node.fontSize < MIN_FONT_SIZE
+			) {
+				issues.push(createTypographyIssue(node));
+			}
+			if (node.type === "TEXT") {
+				await analyzeTextNodeForContrastIssue(node, issues);
+			}
+		}),
+	);
+
+	return issues;
+}

--- a/src/lib/figmaUtils/index.test.ts
+++ b/src/lib/figmaUtils/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { MIN_TOUCH_TARGET_SIZE_AAA, TOUCH_TARGET_MIN_SIZE } from "@/lib/constants";
+import fakeSceneNode from "@/lib/test-utils/fakeSceneNode";
 import solidFill from "@/lib/test-utils/solidFill";
 import {
 	buildTouchTargetSpatialIndex,
@@ -20,18 +21,6 @@ describe("TOUCH_TARGET_MIN_SIZE", () => {
 		expect(TOUCH_TARGET_MIN_SIZE.AAA).toBe(MIN_TOUCH_TARGET_SIZE_AAA);
 	});
 });
-
-function fakeNode(
-	id: string,
-	bounds: { x: number; y: number; width: number; height: number },
-): SceneNode {
-	return {
-		id,
-		width: bounds.width,
-		height: bounds.height,
-		absoluteBoundingBox: bounds,
-	} as unknown as SceneNode;
-}
 
 function fakeTextNode(overrides: Partial<TextNode> = {}): TextNode {
 	return {
@@ -140,19 +129,19 @@ describe("replaceTopmostVisibleSolidFillColor", () => {
 
 describe("isTouchTargetTooSmall", () => {
 	it("returns false when both dimensions meet the 44px minimum", () => {
-		const node = fakeNode("a", { x: 0, y: 0, width: 44, height: 44 });
+		const node = fakeSceneNode("a", { x: 0, y: 0, width: 44, height: 44 });
 
 		expect(isTouchTargetTooSmall(node)).toBe(false);
 	});
 
 	it("returns true when width is below the minimum", () => {
-		const node = fakeNode("a", { x: 0, y: 0, width: 43, height: 44 });
+		const node = fakeSceneNode("a", { x: 0, y: 0, width: 43, height: 44 });
 
 		expect(isTouchTargetTooSmall(node)).toBe(true);
 	});
 
 	it("returns true when height is below the minimum", () => {
-		const node = fakeNode("a", { x: 0, y: 0, width: 44, height: 43 });
+		const node = fakeSceneNode("a", { x: 0, y: 0, width: 44, height: 43 });
 
 		expect(isTouchTargetTooSmall(node)).toBe(true);
 	});
@@ -164,7 +153,7 @@ describe("isTouchTargetTooSmall", () => {
 	});
 
 	it("checks against a custom minSize instead of the default 44px", () => {
-		const node = fakeNode("a", { x: 0, y: 0, width: 30, height: 30 });
+		const node = fakeSceneNode("a", { x: 0, y: 0, width: 30, height: 30 });
 
 		expect(isTouchTargetTooSmall(node)).toBe(true); // fails the default AAA (44px) minimum
 		expect(isTouchTargetTooSmall(node, 24)).toBe(false); // passes the AA (24px) minimum
@@ -172,7 +161,7 @@ describe("isTouchTargetTooSmall", () => {
 });
 
 describe("isTouchTargetTooClose", () => {
-	const node = fakeNode("a", { x: 0, y: 0, width: 44, height: 44 });
+	const node = fakeSceneNode("a", { x: 0, y: 0, width: 44, height: 44 });
 
 	it("returns false when there is no bounding box", () => {
 		const boundsless = { id: "a" } as unknown as SceneNode;
@@ -185,32 +174,32 @@ describe("isTouchTargetTooClose", () => {
 	});
 
 	it("returns false when nodes are far apart", () => {
-		const other = fakeNode("b", { x: 500, y: 500, width: 44, height: 44 });
+		const other = fakeSceneNode("b", { x: 500, y: 500, width: 44, height: 44 });
 
 		expect(isTouchTargetTooClose(node, [node, other])).toBe(false);
 	});
 
 	it("returns true when vertically overlapping nodes are closer than 8px horizontally", () => {
-		const other = fakeNode("b", { x: 49, y: 0, width: 44, height: 44 });
+		const other = fakeSceneNode("b", { x: 49, y: 0, width: 44, height: 44 });
 
 		expect(isTouchTargetTooClose(node, [node, other])).toBe(true);
 	});
 
 	it("returns true when horizontally overlapping nodes are closer than 8px vertically", () => {
-		const other = fakeNode("b", { x: 0, y: 49, width: 44, height: 44 });
+		const other = fakeSceneNode("b", { x: 0, y: 49, width: 44, height: 44 });
 
 		expect(isTouchTargetTooClose(node, [node, other])).toBe(true);
 	});
 
 	it("returns false when overlapping nodes have at least 8px of spacing", () => {
-		const other = fakeNode("b", { x: 52, y: 0, width: 44, height: 44 });
+		const other = fakeSceneNode("b", { x: 52, y: 0, width: 44, height: 44 });
 
 		expect(isTouchTargetTooClose(node, [node, other])).toBe(false);
 	});
 });
 
 describe("getNearbyNodes", () => {
-	const node = fakeNode("a", { x: 0, y: 0, width: 44, height: 44 });
+	const node = fakeSceneNode("a", { x: 0, y: 0, width: 44, height: 44 });
 
 	it("returns an empty array when the node has no bounding box", () => {
 		const boundsless = { id: "a" } as unknown as SceneNode;
@@ -220,14 +209,14 @@ describe("getNearbyNodes", () => {
 	});
 
 	it("finds a node sharing a cell nearby", () => {
-		const other = fakeNode("b", { x: 49, y: 0, width: 44, height: 44 });
+		const other = fakeSceneNode("b", { x: 49, y: 0, width: 44, height: 44 });
 		const index = buildTouchTargetSpatialIndex([node, other]);
 
 		expect(getNearbyNodes(node, index).map((n) => n.id)).toEqual(["b"]);
 	});
 
 	it("excludes nodes far enough away to land in unrelated cells", () => {
-		const far = fakeNode("far", { x: 5000, y: 5000, width: 44, height: 44 });
+		const far = fakeSceneNode("far", { x: 5000, y: 5000, width: 44, height: 44 });
 		const index = buildTouchTargetSpatialIndex([node, far]);
 
 		expect(getNearbyNodes(node, index)).toEqual([]);
@@ -240,7 +229,7 @@ describe("getNearbyNodes", () => {
 	});
 
 	it("does not return duplicates when a large node spans multiple shared cells", () => {
-		const big = fakeNode("big", { x: 0, y: 0, width: 500, height: 500 });
+		const big = fakeSceneNode("big", { x: 0, y: 0, width: 500, height: 500 });
 		const index = buildTouchTargetSpatialIndex([node, big], 100);
 
 		const nearby = getNearbyNodes(node, index, 100);
@@ -257,8 +246,8 @@ describe("getNearbyNodes", () => {
 	});
 
 	it("agrees with the naive isTouchTargetTooClose result when passed the full node list vs. just the nearby subset", () => {
-		const close = fakeNode("close", { x: 49, y: 0, width: 44, height: 44 });
-		const far = fakeNode("far", { x: 5000, y: 5000, width: 44, height: 44 });
+		const close = fakeSceneNode("close", { x: 49, y: 0, width: 44, height: 44 });
+		const far = fakeSceneNode("far", { x: 5000, y: 5000, width: 44, height: 44 });
 		const allNodes = [node, close, far];
 		const index = buildTouchTargetSpatialIndex(allNodes);
 
@@ -282,7 +271,7 @@ describe("spatial index performance", () => {
 			const col = i % columns;
 			const row = Math.floor(i / columns);
 			nodes.push(
-				fakeNode(`n${i}`, {
+				fakeSceneNode(`n${i}`, {
 					x: col * gridStride,
 					y: row * gridStride,
 					width: 44,
@@ -295,8 +284,8 @@ describe("spatial index performance", () => {
 		// spacing violations to find, not just distant nodes.
 		for (let i = 0; i < 20; i++) {
 			nodes.push(
-				fakeNode(`close-a-${i}`, { x: i * 1000, y: 0, width: 44, height: 44 }),
-				fakeNode(`close-b-${i}`, { x: i * 1000 + 49, y: 0, width: 44, height: 44 }),
+				fakeSceneNode(`close-a-${i}`, { x: i * 1000, y: 0, width: 44, height: 44 }),
+				fakeSceneNode(`close-b-${i}`, { x: i * 1000 + 49, y: 0, width: 44, height: 44 }),
 			);
 		}
 
@@ -461,12 +450,10 @@ describe("createTouchTargetIssue", () => {
 		type: SceneNode["type"],
 		dimensions?: { width: number; height: number },
 	): SceneNode {
-		return {
-			id,
+		return fakeSceneNode(id, dimensions ? { x: 0, y: 0, ...dimensions } : undefined, {
 			name: "Icon button",
 			type,
-			...dimensions,
-		} as unknown as SceneNode;
+		});
 	}
 
 	it("returns null and logs an error for an invalid node", () => {

--- a/src/lib/test-utils/fakeSceneNode/index.test.ts
+++ b/src/lib/test-utils/fakeSceneNode/index.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import fakeSceneNode from "./index";
+
+describe("fakeSceneNode", () => {
+	it("builds a node with id, default name/type, and no geometry when bounds is omitted", () => {
+		const node = fakeSceneNode("a");
+
+		expect(node).toEqual({ id: "a", name: "Node", type: "FRAME" });
+	});
+
+	it("includes width/height/absoluteBoundingBox when bounds is given", () => {
+		const bounds = { x: 0, y: 0, width: 44, height: 44 };
+
+		const node = fakeSceneNode("a", bounds);
+
+		expect(node).toEqual({
+			id: "a",
+			name: "Node",
+			type: "FRAME",
+			width: 44,
+			height: 44,
+			absoluteBoundingBox: bounds,
+		});
+	});
+
+	it("supports overriding name and type", () => {
+		const node = fakeSceneNode("a", undefined, { name: "Icon button", type: "GROUP" });
+
+		expect(node).toEqual({ id: "a", name: "Icon button", type: "GROUP" });
+	});
+});

--- a/src/lib/test-utils/fakeSceneNode/index.ts
+++ b/src/lib/test-utils/fakeSceneNode/index.ts
@@ -1,0 +1,30 @@
+export type FakeSceneNodeBounds = { x: number; y: number; width: number; height: number };
+
+export type FakeSceneNodeOverrides = {
+	name?: string;
+	type?: SceneNode["type"];
+};
+
+/**
+ * Fake SceneNode for tests that only need id/geometry (touch-target
+ * size/spacing, spatial-index) and/or name/type (touch-target eligibility,
+ * issue builders) - not the full Figma node shape. Omitting `bounds`
+ * omits width/height/absoluteBoundingBox entirely, for tests covering a
+ * node type that doesn't support them.
+ */
+export default function fakeSceneNode(
+	id: string,
+	bounds?: FakeSceneNodeBounds,
+	overrides: FakeSceneNodeOverrides = {},
+): SceneNode {
+	const { name = "Node", type = "FRAME" } = overrides;
+
+	return {
+		id,
+		name,
+		type,
+		...(bounds
+			? { width: bounds.width, height: bounds.height, absoluteBoundingBox: bounds }
+			: {}),
+	} as unknown as SceneNode;
+}


### PR DESCRIPTION
## Summary
`plugin/code.ts` (the Figma sandbox bundle, `@ts-nocheck`, outside Vitest's reach) mixed genuine `figma.*` orchestration with scan/collection logic that didn't need to live there — including the touch-target eligibility/spatial-index wiring from the O(n^2) perf fix (#48), which had zero integration coverage.

- New `src/lib/figmaUtils/collectIssues/index.ts`: `isScannable`, `collectTouchTargetIssues` (no `figma.*` references — `isTouchTarget`'s only async call is a method on the node itself — fully unit-testable), `collectTextNodeIssues` (font loading, genuinely Figma-runtime-only), `collectIssues`, and `detectIssuesInSelection` (now takes its spacing-check candidate pool as a parameter instead of reading `figma.currentPage.children` internally, removing its last direct `figma.*` reference).
- `plugin/code.ts` shrunk from 357 to ~230 lines — now only message routing, `selectionchange`, `clientStorage`, and the other `handle*` wrappers.
- Extracted a shared `fakeSceneNode` test fixture (`src/lib/test-utils`) to replace three near-identical local fake-`SceneNode` constructors that had accumulated across the two `figmaUtils` test files.

## Test plan
- [x] 14 new tests for the extracted module, covering exactly what was previously untested: touch-target eligibility/spatial-index wiring, the `deviceType`/`targetLevel` branching, and the spacing-candidate-pool wiring
- [x] Mutation-tested the `deviceType === "touch"` gate and the `candidateNodesForSpacing` wiring (broke each, confirmed the relevant test failed, restored)
- [x] `tsc -b`, `npm run lint`, `npm run test` (277 passing), `npm run build` all clean
- [ ] `collectTextNodeIssues` (font loading + contrast) remains Figma-runtime-only, same as before this refactor — still needs manual verification in Figma dev mode if that path is touched