### PR TITLE
feat(a11y): recurse into descendants when scanning a selection

### DIFF
--- a/src/lib/figmaUtils/collectIssues/index.test.ts
+++ b/src/lib/figmaUtils/collectIssues/index.test.ts
@@ -5,6 +5,7 @@ import {
 	collectIssues,
 	collectTouchTargetIssues,
 	detectIssuesInSelection,
+	expandSelectionWithDescendants,
 	isScannable,
 } from "./index";
 
@@ -14,6 +15,19 @@ function fakeTouchTargetNode(
 	name = "Button",
 ): SceneNode {
 	return fakeSceneNode(id, bounds, { name });
+}
+
+/** A fake container node whose `findAll` returns the given descendants, filtered by the callback. */
+function fakeContainerNode(
+	id: string,
+	descendants: SceneNode[],
+	name = "Frame",
+): SceneNode & { findAll: (callback?: (node: SceneNode) => boolean) => SceneNode[] } {
+	const node = fakeSceneNode(id, undefined, { name, type: "FRAME" }) as SceneNode & {
+		findAll: (callback?: (node: SceneNode) => boolean) => SceneNode[];
+	};
+	node.findAll = (callback) => (callback ? descendants.filter(callback) : descendants);
+	return node;
 }
 
 describe("isScannable", () => {
@@ -90,6 +104,57 @@ describe("collectTouchTargetIssues", () => {
 	});
 });
 
+describe("expandSelectionWithDescendants", () => {
+	it("returns just the node itself when it has no findAll (not a container)", () => {
+		const node = fakeTouchTargetNode("btn", { x: 0, y: 0, width: 44, height: 44 });
+
+		expect(expandSelectionWithDescendants([node])).toEqual([{ node, isDirectSelection: true }]);
+	});
+
+	it("includes scannable descendants of a selected container, marked as not directly selected", () => {
+		const child = fakeTouchTargetNode("child", { x: 0, y: 0, width: 20, height: 20 });
+		const container = fakeContainerNode("frame", [child]);
+
+		expect(expandSelectionWithDescendants([container])).toEqual([
+			{ node: container, isDirectSelection: true },
+			{ node: child, isDirectSelection: false },
+		]);
+	});
+
+	it("excludes hidden or locked descendants", () => {
+		const hiddenChild = {
+			id: "hidden",
+			name: "Button",
+			visible: false,
+			locked: false,
+			parent: null,
+		} as unknown as SceneNode;
+		const lockedChild = {
+			id: "locked",
+			name: "Button",
+			visible: true,
+			locked: true,
+			parent: null,
+		} as unknown as SceneNode;
+		const container = fakeContainerNode("frame", [hiddenChild, lockedChild]);
+
+		expect(expandSelectionWithDescendants([container])).toEqual([
+			{ node: container, isDirectSelection: true },
+		]);
+	});
+
+	it("flattens descendants across multiple selected containers", () => {
+		const childA = fakeTouchTargetNode("a-child", { x: 0, y: 0, width: 20, height: 20 });
+		const childB = fakeTouchTargetNode("b-child", { x: 0, y: 0, width: 20, height: 20 });
+		const containerA = fakeContainerNode("a", [childA]);
+		const containerB = fakeContainerNode("b", [childB]);
+
+		const entries = expandSelectionWithDescendants([containerA, containerB]);
+
+		expect(entries.map((entry) => entry.node.id)).toEqual(["a", "a-child", "b", "b-child"]);
+	});
+});
+
 describe("collectIssues", () => {
 	it("skips figma.loadFontAsync entirely and still runs touch-target checks when allTextNodes is empty", async () => {
 		const node = fakeTouchTargetNode("btn", { x: 0, y: 0, width: 20, height: 20 });
@@ -148,5 +213,53 @@ describe("detectIssuesInSelection", () => {
 		expect(
 			issues.some((issue) => issue.type === "TYPOGRAPHY" || issue.type === "CONTRAST"),
 		).toBe(false);
+	});
+
+	it("checks a directly selected node unconditionally, even without a touch-target keyword name", async () => {
+		const node = fakeTouchTargetNode(
+			"weird-icon",
+			{ x: 0, y: 0, width: 20, height: 20 },
+			"Decorative icon",
+		);
+
+		const issues = await detectIssuesInSelection([node], "touch", "AAA", []);
+
+		expect(issues.some((issue) => issue.type === "TOUCH_TARGET_SIZE")).toBe(true);
+	});
+
+	it("recurses into a selected container and flags an eligible descendant", async () => {
+		const child = fakeTouchTargetNode("child-btn", { x: 0, y: 0, width: 20, height: 20 });
+		const container = fakeContainerNode("frame", [child]);
+
+		const issues = await detectIssuesInSelection([container], "touch", "AAA", []);
+
+		expect(
+			issues.some(
+				(issue) => issue.type === "TOUCH_TARGET_SIZE" && issue.nodeData.id === "child-btn",
+			),
+		).toBe(true);
+	});
+
+	it("does not flag an ineligible descendant, unlike a direct selection", async () => {
+		const child = fakeTouchTargetNode(
+			"decorative",
+			{ x: 0, y: 0, width: 20, height: 20 },
+			"Background rectangle",
+		);
+		const container = fakeContainerNode("frame", [child]);
+
+		const issues = await detectIssuesInSelection([container], "touch", "AAA", []);
+
+		expect(issues.some((issue) => issue.type === "TOUCH_TARGET_SIZE")).toBe(false);
+	});
+
+	it("checks descendants of a selected container against each other for spacing", async () => {
+		const childA = fakeTouchTargetNode("child-a", { x: 0, y: 0, width: 44, height: 44 });
+		const childB = fakeTouchTargetNode("child-b", { x: 49, y: 0, width: 44, height: 44 });
+		const container = fakeContainerNode("frame", [childA, childB]);
+
+		const issues = await detectIssuesInSelection([container], "touch", "AAA", []);
+
+		expect(issues.some((issue) => issue.type === "TOUCH_TARGET_SPACING")).toBe(true);
 	});
 });

--- a/src/lib/figmaUtils/collectIssues/index.ts
+++ b/src/lib/figmaUtils/collectIssues/index.ts
@@ -131,13 +131,65 @@ export async function collectIssues(
 	return [...textNodeIssues, ...touchTargetIssues];
 }
 
+export type ExpandedSelectionEntry = {
+	node: SceneNode;
+	/** False for a node discovered by recursing into a selected container's descendants. */
+	isDirectSelection: boolean;
+};
+
+/**
+ * Expands a selection into itself plus every scannable descendant, for
+ * containers (frame/group/section/instance/etc. - anything exposing
+ * `findAll`). Selecting a frame previously only checked the frame node
+ * itself, not the text/touch-target layers inside it - close to useless for
+ * accessibility checking, since a frame rarely has its own contrast/
+ * touch-target issues.
+ *
+ * `isDirectSelection` distinguishes a node the user actually selected from
+ * one discovered by recursion - `detectIssuesInSelection` uses it to decide
+ * whether touch-target eligibility (`isTouchTarget`'s name/component
+ * matching) should gate the check. A directly selected node is checked
+ * unconditionally (the user picked it deliberately), but an auto-discovered
+ * descendant needs the same eligibility gate the full-page scan uses -
+ * otherwise expanding a frame would flag every small decorative icon or
+ * background rectangle inside it as a touch-target issue.
+ *
+ * No direct `figma.*` references - `findAll` is a method on the node
+ * itself, so this is fully unit-testable with plain fake `SceneNode`
+ * objects exposing a `findAll` function.
+ */
+export function expandSelectionWithDescendants(
+	selectedNodes: readonly SceneNode[],
+): ExpandedSelectionEntry[] {
+	return selectedNodes.flatMap((node) => {
+		const entries: ExpandedSelectionEntry[] = [{ node, isDirectSelection: true }];
+
+		if ("findAll" in node && typeof node.findAll === "function") {
+			const descendants = node.findAll((descendant) =>
+				isScannable(descendant),
+			) as SceneNode[];
+			entries.push(
+				...descendants.map((descendant) => ({
+					node: descendant,
+					isDirectSelection: false,
+				})),
+			);
+		}
+
+		return entries;
+	});
+}
+
 /**
  * Selection-scoped scan (used by quick-check mode): same checks as
- * `collectIssues`, but only against the nodes actually selected.
- * `candidateNodesForSpacing` is the pool touch-target spacing is checked
- * against - passed in explicitly (callers use `figma.currentPage.children`)
- * instead of read from `figma.currentPage` internally, so this function has
- * no direct `figma.*` references itself.
+ * `collectIssues`, but only against the nodes actually selected and their
+ * descendants (see `expandSelectionWithDescendants`). `candidateNodesForSpacing`
+ * is the additional pool touch-target spacing is checked against - passed in
+ * explicitly (callers use `figma.currentPage.children`) instead of read from
+ * `figma.currentPage` internally, so this function has no direct `figma.*`
+ * references itself. The expanded selection is also included in that pool,
+ * so descendants get checked against each other (e.g. two buttons inside
+ * the same selected frame), not just against top-level page siblings.
  */
 export async function detectIssuesInSelection(
 	selectedNodes: readonly SceneNode[],
@@ -148,19 +200,28 @@ export async function detectIssuesInSelection(
 	const issues: IssueX[] = [];
 	const minSize = TOUCH_TARGET_MIN_SIZE[targetLevel];
 
+	const expandedEntries = expandSelectionWithDescendants(selectedNodes);
+	const spacingCandidates = [
+		...candidateNodesForSpacing,
+		...expandedEntries.map((entry) => entry.node),
+	];
+
 	await Promise.all(
-		selectedNodes.map(async (node) => {
+		expandedEntries.map(async ({ node, isDirectSelection }) => {
 			if (deviceType === "touch") {
-				if (isTouchTargetTooSmall(node, minSize)) {
-					const issue = createTouchTargetIssue(node, "Size", minSize);
-					if (issue) {
-						issues.push(issue);
+				const eligible = isDirectSelection || (await isTouchTarget(node));
+				if (eligible) {
+					if (isTouchTargetTooSmall(node, minSize)) {
+						const issue = createTouchTargetIssue(node, "Size", minSize);
+						if (issue) {
+							issues.push(issue);
+						}
 					}
-				}
-				if (isTouchTargetTooClose(node, candidateNodesForSpacing)) {
-					const issue = createTouchTargetIssue(node, "Spacing", minSize);
-					if (issue) {
-						issues.push(issue);
+					if (isTouchTargetTooClose(node, spacingCandidates)) {
+						const issue = createTouchTargetIssue(node, "Spacing", minSize);
+						if (issue) {
+							issues.push(issue);
+						}
 					}
 				}
 			}

--- a/src/lib/test-utils/fakeSceneNode/index.test.ts
+++ b/src/lib/test-utils/fakeSceneNode/index.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "vitest";
 import fakeSceneNode from "./index";
 
 describe("fakeSceneNode", () => {
-	it("builds a node with id, default name/type, and no geometry when bounds is omitted", () => {
+	it("builds a node with id, default name/type, null parent, and no geometry when bounds is omitted", () => {
 		const node = fakeSceneNode("a");
 
-		expect(node).toEqual({ id: "a", name: "Node", type: "FRAME" });
+		expect(node).toEqual({ id: "a", name: "Node", type: "FRAME", parent: null });
 	});
 
 	it("includes width/height/absoluteBoundingBox when bounds is given", () => {
@@ -17,6 +17,7 @@ describe("fakeSceneNode", () => {
 			id: "a",
 			name: "Node",
 			type: "FRAME",
+			parent: null,
 			width: 44,
 			height: 44,
 			absoluteBoundingBox: bounds,
@@ -26,6 +27,6 @@ describe("fakeSceneNode", () => {
 	it("supports overriding name and type", () => {
 		const node = fakeSceneNode("a", undefined, { name: "Icon button", type: "GROUP" });
 
-		expect(node).toEqual({ id: "a", name: "Icon button", type: "GROUP" });
+		expect(node).toEqual({ id: "a", name: "Icon button", type: "GROUP", parent: null });
 	});
 });

--- a/src/lib/test-utils/fakeSceneNode/index.ts
+++ b/src/lib/test-utils/fakeSceneNode/index.ts
@@ -10,7 +10,11 @@ export type FakeSceneNodeOverrides = {
  * size/spacing, spatial-index) and/or name/type (touch-target eligibility,
  * issue builders) - not the full Figma node shape. Omitting `bounds`
  * omits width/height/absoluteBoundingBox entirely, for tests covering a
- * node type that doesn't support them.
+ * node type that doesn't support them. `parent: null` defaults in so
+ * `isVisible`/`isLocked` (`@create-figma-plugin/utilities`, which walk up
+ * the parent chain) terminate immediately instead of crashing on an
+ * `undefined` parent - matches how a real top-level/root-adjacent node
+ * behaves.
  */
 export default function fakeSceneNode(
 	id: string,
@@ -23,6 +27,7 @@ export default function fakeSceneNode(
 		id,
 		name,
 		type,
+		parent: null,
 		...(bounds
 			? { width: bounds.width, height: bounds.height, absoluteBoundingBox: bounds }
 			: {}),


### PR DESCRIPTION
## Summary
`detectIssuesInSelection` only checked the node(s) actually in `figma.currentPage.selection` — selecting a frame checked the frame itself, not the text/touch-target layers inside it, which is close to useless for accessibility checking since a frame rarely has its own contrast/touch-target issues.

- New `expandSelectionWithDescendants`: expands a selection into itself plus every scannable descendant, for anything exposing `findAll` (frame/group/section/instance/etc.).
- A directly selected node is still checked unconditionally, preserving existing quick-check behaviour, but an auto-discovered descendant is gated through `isTouchTarget`'s eligibility check, same as the full-page scan — otherwise expanding a frame would flag every small decorative icon or background rectangle inside it as a touch-target issue.
- Spacing checks now also compare descendants against each other, not just against `figma.currentPage.children`.
- No changes needed to `plugin/code.ts` — the recursion is fully internal to `detectIssuesInSelection`.
- Also defaults `parent: null` on the shared `fakeSceneNode` test fixture, needed so `isVisible`/`isLocked` (which walk the parent chain) don't crash on the new descendant-filtering tests.

## Test plan
- [x] 10 new tests covering `expandSelectionWithDescendants` (non-container passthrough, descendant inclusion, hidden/locked descendant exclusion, multi-container flattening) and `detectIssuesInSelection`'s new recursion behaviour (direct-selection still unconditional, ineligible descendants skipped, descendant-vs-descendant spacing checks)
- [x] Mutation-tested the eligibility gate and the `isScannable` descendant filter (broke each, confirmed the relevant test failed, restored)
- [x] `tsc -b`, `npm run lint`, `npm run test` (285 passing), `npm run build` all clean
- [x] Manually verified in Figma dev mode