### PR TITLE
fix(a11y): make issue recommendation/description copy target-level aware

### DIFF
--- a/src/components/organisms/AccessibilityValidator/index.tsx
+++ b/src/components/organisms/AccessibilityValidator/index.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { MESSAGE_TYPES } from "@/lib/constants";
 import ISSUE_TYPE_LABELS from "@/lib/issueTypeLabels";
 import { postMessageToBackend } from "@/lib/figmaUtils";
-import { ISSUES_DATA_SCHEMA } from "@/lib/issuesData";
+import ISSUES_DATA_SCHEMA from "@/lib/issuesData";
 import { IssueType } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
 import { cn, getRouteForIssueType } from "@/lib/utils";

--- a/src/components/organisms/IssuesOverviewList/index.test.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.test.tsx
@@ -222,4 +222,20 @@ describe("IssuesOverviewList", () => {
 
 		expect(saveAs).toHaveBeenCalledWith(expect.any(Blob), "accessibility-issues-report.json");
 	});
+
+	it("exports a target-level-aware contrast description, not the stale 'below WCAG AA standard' text", async () => {
+		const user = userEvent.setup();
+		useIssuesStore.setState({ issues: [contrastPassIssue], targetLevel: "AAA" });
+		render(<IssuesOverviewList />);
+
+		await goToReportTab(user);
+		await user.click(screen.getByRole("button", { name: "Download JSON" }));
+
+		const blob = saveAs.mock.calls[0][0] as Blob;
+		const content = JSON.parse(await blob.text());
+
+		expect(content[0].description).toBe(
+			"Text contrast meets WCAG AA but is below the stricter WCAG AAA standard.",
+		);
+	});
 });

--- a/src/components/organisms/IssuesOverviewList/index.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.tsx
@@ -3,10 +3,16 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ISSUES_TYPES, MESSAGE_TYPES } from "@/lib/constants";
 import ISSUE_TYPE_LABELS from "@/lib/issueTypeLabels";
-import { ISSUES_DATA_SCHEMA } from "@/lib/issuesData";
+import ISSUES_DATA_SCHEMA from "@/lib/issuesData";
 import { IssueType, IssueX } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
-import { cn, contrastFailsTargetLevel, getRouteForIssueType, getSeverityStyles } from "@/lib/utils";
+import {
+	cn,
+	contrastFailsTargetLevel,
+	getContrastIssueDescription,
+	getRouteForIssueType,
+	getSeverityStyles,
+} from "@/lib/utils";
 import { saveAs } from "file-saver";
 import { ChevronLeft, ChevronRight, RefreshCcw } from "lucide-react";
 import { useEffect } from "react";
@@ -83,10 +89,22 @@ export default function IssuesOverviewList() {
 				issue.nodeData?.nodeType === "TEXT"
 					? issue.nodeData?.characters
 					: issue.nodeData?.name;
+			// Contrast's description depends on the live targetLevel, not just
+			// what was true at scan time - toggling AA/AAA doesn't rescan, so an
+			// issue exported while browsing at AAA needs different copy than the
+			// same issue exported while browsing at AA.
+			const description =
+				issue.type === "CONTRAST"
+					? getContrastIssueDescription(
+							issue.nodeData.contrastScore?.compliance,
+							targetLevel,
+						)
+					: issue.description;
+
 			return {
 				elementType: issue.nodeData?.nodeType || "N/A",
 				elementName: elementName || "N/A",
-				description: issue.description,
+				description,
 				severity: issue.severity,
 				type: (issue.type && ISSUE_TYPE_LABELS[issue.type]) || issue.type,
 				wcagContrastScore: issue.nodeData?.contrastScore?.compliance || "N/A",

--- a/src/components/organisms/IssuesWrapper/index.test.tsx
+++ b/src/components/organisms/IssuesWrapper/index.test.tsx
@@ -39,7 +39,6 @@ const touchTargetIssue: IssueX = {
 
 const contrastFailIssue: IssueX = {
 	type: "CONTRAST",
-	description: "Text contrast is below WCAG AA standard.",
 	severity: "critical",
 	nodeData: {
 		id: "c1",
@@ -49,12 +48,22 @@ const contrastFailIssue: IssueX = {
 	},
 };
 
+const contrastAaOnlyIssue: IssueX = {
+	...contrastFailIssue,
+	nodeData: {
+		...contrastFailIssue.nodeData,
+		id: "c2",
+		contrastScore: { compliance: "AA", ratio: 5 },
+	},
+};
+
 const defaultState = {
 	issues: [] as IssueX[],
 	singleIssue: null,
 	currentIndex: 0,
 	currentRoute: "INDEX" as const,
 	selectedType: "" as const,
+	targetLevel: "AA" as const,
 };
 
 describe("IssuesWrapper", () => {
@@ -198,5 +207,57 @@ describe("IssuesWrapper", () => {
 		expect(screen.getByText("Text size is too small for readability.")).toBeVisible();
 		expect(screen.getByText("Row content")).toBeVisible();
 		expect(screen.getByText("Recommendations")).toBeVisible();
+	});
+
+	it("describes a genuine AA contrast failure as below WCAG AA standard", () => {
+		useIssuesStore.setState({
+			selectedType: "CONTRAST",
+			issues: [contrastFailIssue],
+			targetLevel: "AA",
+		});
+		render(<IssuesWrapper>child</IssuesWrapper>);
+
+		expect(screen.getByText("Text contrast is below WCAG AA standard.")).toBeVisible();
+	});
+
+	it("describes an AA-passing/AAA-failing issue without falsely claiming it fails AA", () => {
+		useIssuesStore.setState({
+			selectedType: "CONTRAST",
+			issues: [contrastAaOnlyIssue],
+			targetLevel: "AAA",
+		});
+		render(<IssuesWrapper>child</IssuesWrapper>);
+
+		expect(
+			screen.getByText(
+				"Text contrast meets WCAG AA but is below the stricter WCAG AAA standard.",
+			),
+		).toBeVisible();
+		expect(screen.queryByText("Text contrast is below WCAG AA standard.")).toBeNull();
+	});
+
+	it("cites the stricter AAA contrast ratios in the recommendation when the target level is AAA", async () => {
+		const user = userEvent.setup();
+		useIssuesStore.setState({
+			selectedType: "CONTRAST",
+			issues: [contrastAaOnlyIssue],
+			targetLevel: "AAA",
+		});
+		render(<IssuesWrapper>child</IssuesWrapper>);
+
+		await user.click(screen.getByRole("button", { name: "Toggle Recommendations" }));
+
+		expect(screen.getByText(/7:1 for normal text and 4.5:1 for large text/)).toBeVisible();
+	});
+
+	it("shows the description for a quick-check singleIssue even though issueGroupList is empty", () => {
+		useIssuesStore.setState({
+			selectedType: "TYPOGRAPHY",
+			issues: [],
+			singleIssue: typographyIssue,
+		});
+		render(<IssuesWrapper>child</IssuesWrapper>);
+
+		expect(screen.getByText("Text size is too small for readability.")).toBeVisible();
 	});
 });

--- a/src/components/organisms/IssuesWrapper/index.tsx
+++ b/src/components/organisms/IssuesWrapper/index.tsx
@@ -5,10 +5,11 @@ import Separator from "@/components/ui/separator";
 import { MESSAGE_TYPES } from "@/lib/constants";
 import ISSUE_TYPE_LABELS from "@/lib/issueTypeLabels";
 import { postMessageToBackend } from "@/lib/figmaUtils";
-import { ISSUE_RECOMMENDATIONS, ISSUES_DATA_SCHEMA } from "@/lib/issuesData";
+import getIssueRecommendations from "@/lib/issueRecommendations";
+import ISSUES_DATA_SCHEMA from "@/lib/issuesData";
 import { IssueType, IssueX } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
-import { cn, getRouteForIssueType } from "@/lib/utils";
+import { cn, getContrastIssueDescription, getRouteForIssueType } from "@/lib/utils";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -42,6 +43,7 @@ export default function IssuesWrapper({ children }: { children: React.ReactNode 
 		issues,
 		singleIssue,
 		selectedType,
+		targetLevel,
 		navigateTo,
 		setCurrentIndex,
 		setSelectedType,
@@ -127,7 +129,13 @@ export default function IssuesWrapper({ children }: { children: React.ReactNode 
 
 	const issueGroupList = getIssueGroupList();
 	const currentIssue = issueGroupList[currentIndex];
-	const { type, description } = currentIssue || {};
+	// The issue actually being rendered below (see renderWrapper's call site) -
+	// singleIssue in quick-check mode, currentIssue when paging a scanned
+	// list. description/suggestions need to derive from whichever one that
+	// actually is, not always currentIssue, or quick-check mode would compute
+	// them from an issue that isn't the one on screen.
+	const activeIssue = issueGroupList.length === 0 ? singleIssue : currentIssue;
+	const { type } = activeIssue || {};
 	const availableTypes = ISSUES_DATA_SCHEMA.filter((issue) =>
 		issues.some((i) => i.type === issue.type),
 	);
@@ -135,14 +143,23 @@ export default function IssuesWrapper({ children }: { children: React.ReactNode 
 	const currentOrSelectedType = type ?? selectedType;
 	const headerLabel = currentOrSelectedType ? ISSUE_TYPE_LABELS[currentOrSelectedType] : "";
 
-	const getIssueRecommendations = (issueType: IssueType | "") => {
-		if (!issueType) return null;
-		const label = ISSUE_TYPE_LABELS[issueType].toLowerCase();
-		const entry = ISSUE_RECOMMENDATIONS.find((item) => item[label] !== undefined);
-		return entry ? entry[label] : null;
-	};
+	// Contrast's description depends on the live targetLevel, not just what
+	// was true at scan time - target-level filtering is instant/client-side
+	// (toggling AA/AAA doesn't rescan), so the same stored issue needs
+	// different copy depending on which level is currently selected.
+	const description =
+		activeIssue?.type === "CONTRAST"
+			? getContrastIssueDescription(
+					activeIssue.nodeData.contrastScore?.compliance,
+					targetLevel,
+				)
+			: activeIssue?.description;
 
-	const suggestions = getIssueRecommendations(selectedType);
+	const suggestions = getIssueRecommendations(
+		selectedType,
+		targetLevel,
+		activeIssue?.nodeData?.requiredSizePx,
+	);
 
 	const renderWrapper = (issue: typeof singleIssue | null) => {
 		if (!issue) {

--- a/src/lib/figmaUtils/index.test.ts
+++ b/src/lib/figmaUtils/index.test.ts
@@ -405,7 +405,6 @@ describe("createContrastIssue", () => {
 		};
 
 		expect(createContrastIssue(node, contrastScore, [0, 0, 0], background, true)).toEqual({
-			description: "Text contrast is below WCAG AA standard.",
 			severity: "critical",
 			type: "CONTRAST",
 			nodeData: {
@@ -441,6 +440,18 @@ describe("createContrastIssue", () => {
 		expect(issue.nodeData.backgroundNodeName).toBeUndefined();
 		expect(issue.nodeData.backgroundSharedWithCount).toBeUndefined();
 		expect(issue.nodeData.isBold).toBe(false);
+	});
+
+	it("does not set a static description - contrastScore.compliance drives the description at render/report time instead", () => {
+		const issue = createContrastIssue(
+			fakeTextNode(),
+			{ compliance: "AA", ratio: 5 },
+			[0, 0, 0],
+			null,
+			false,
+		);
+
+		expect(issue.description).toBeUndefined();
 	});
 });
 

--- a/src/lib/figmaUtils/index.ts
+++ b/src/lib/figmaUtils/index.ts
@@ -363,7 +363,11 @@ export const createContrastIssue = (
 	background: BackgroundColorResult | null,
 	isBold: boolean,
 ): IssueX => ({
-	description: "Text contrast is below WCAG AA standard.",
+	// No static description here - contrast target-level filtering is
+	// instant/client-side (toggling AA/AAA doesn't rescan), so a description
+	// baked in at scan time can't reflect whichever level is later selected.
+	// getContrastIssueDescription (utils) derives it at render/report time
+	// instead, from contrastScore.compliance and the live targetLevel.
 	severity: "critical",
 	type: "CONTRAST",
 	nodeData: {

--- a/src/lib/issueRecommendations/index.test.ts
+++ b/src/lib/issueRecommendations/index.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { MIN_TOUCH_TARGET_SIZE_AAA } from "../constants";
+import getIssueRecommendations from "./index";
+
+describe("getIssueRecommendations", () => {
+	it("returns null when no issue type is given", () => {
+		expect(getIssueRecommendations("", "AA")).toBeNull();
+	});
+
+	it("cites the AA contrast ratios when the target level is AA", () => {
+		const recommendations = getIssueRecommendations("CONTRAST", "AA");
+
+		expect(recommendations?.[0]).toContain("4.5:1 for normal text and 3:1 for large text");
+		expect(recommendations?.[0]).toContain("WCAG AA");
+	});
+
+	it("cites the stricter AAA contrast ratios when the target level is AAA", () => {
+		const recommendations = getIssueRecommendations("CONTRAST", "AAA");
+
+		expect(recommendations?.[0]).toContain("7:1 for normal text and 4.5:1 for large text");
+		expect(recommendations?.[0]).toContain("WCAG AAA");
+	});
+
+	it("cites the issue's actual required size for touch-target size, not a hardcoded value", () => {
+		const recommendations = getIssueRecommendations("TOUCH_TARGET_SIZE", "AA", 24);
+
+		expect(recommendations?.[0]).toContain("at least 24x24 pixels");
+	});
+
+	it("falls back to the AAA size for touch-target size when requiredSizePx is omitted", () => {
+		const recommendations = getIssueRecommendations("TOUCH_TARGET_SIZE", "AAA");
+
+		expect(recommendations?.[0]).toContain(
+			`at least ${MIN_TOUCH_TARGET_SIZE_AAA}x${MIN_TOUCH_TARGET_SIZE_AAA} pixels`,
+		);
+	});
+
+	it("returns the same static recommendation for typography regardless of target level", () => {
+		expect(getIssueRecommendations("TYPOGRAPHY", "AA")).toEqual(
+			getIssueRecommendations("TYPOGRAPHY", "AAA"),
+		);
+	});
+
+	it("returns the same static recommendation for touch-target spacing regardless of target level", () => {
+		expect(getIssueRecommendations("TOUCH_TARGET_SPACING", "AA")).toEqual(
+			getIssueRecommendations("TOUCH_TARGET_SPACING", "AAA"),
+		);
+	});
+});

--- a/src/lib/issueRecommendations/index.ts
+++ b/src/lib/issueRecommendations/index.ts
@@ -1,0 +1,69 @@
+import { MIN_FONT_SIZE, MIN_TOUCH_TARGET_SIZE_AAA } from "../constants";
+import ISSUE_TYPE_LABELS from "../issueTypeLabels";
+import { IssueRecommendations, IssueType, TargetLevel } from "../types";
+
+/**
+ * Recommendations that don't depend on which WCAG target level is currently
+ * selected - contrast and touch-target-size are handled separately in
+ * getIssueRecommendations below, since their required ratio/size changes
+ * with the target level.
+ */
+const ISSUE_RECOMMENDATIONS: IssueRecommendations[] = [
+	{
+		typography: [
+			`Ensure font size is at least ${MIN_FONT_SIZE}px to enhance readability and comply with WCAG "AA" standards.`,
+			"Use a minimum font size of 16px for body text and 14px for buttons and other interactive elements.",
+		],
+	},
+	{
+		"touch target spacing": [
+			"The touch target spacing should be at least 8px to the nearest element in all directions.",
+		],
+	},
+];
+
+/** WCAG 1.4.3/1.4.6 contrast ratio thresholds, keyed by target level. */
+const CONTRAST_RATIO_THRESHOLDS: Record<TargetLevel, { normal: number; large: number }> = {
+	AA: { normal: 4.5, large: 3 },
+	AAA: { normal: 7, large: 4.5 },
+};
+
+/**
+ * Recommendation copy for the given issue type, target level, and (for
+ * touch-target size) the actual required size the flagged node was checked
+ * against. Computed here rather than a flat static-by-type lookup because
+ * contrast's required ratio and touch-target size's required size both
+ * depend on which WCAG level is currently selected - a recommendation that
+ * always cited the AA ratio/size was actively wrong advice once AAA was
+ * what was actually being checked against (see
+ * roadmap/IMPROVEMENT_IDEAS.md's "Issue recommendation/description copy"
+ * entry). `requiredSizePx` should come from the specific issue's own
+ * `nodeData.requiredSizePx`, which every TOUCH_TARGET_SIZE issue already
+ * carries from scan time; falls back to the AAA value if omitted.
+ */
+export default function getIssueRecommendations(
+	issueType: IssueType | "",
+	targetLevel: TargetLevel,
+	requiredSizePx?: number,
+): string[] | null {
+	if (!issueType) return null;
+
+	if (issueType === "CONTRAST") {
+		const { normal, large } = CONTRAST_RATIO_THRESHOLDS[targetLevel];
+		return [
+			`Increase the contrast ratio to at least ${normal}:1 for normal text and ${large}:1 for large text (18px and up) to meet WCAG ${targetLevel}.`,
+			"To improve contrast, use a darker text color or a lighter background color.",
+		];
+	}
+
+	if (issueType === "TOUCH_TARGET_SIZE") {
+		const minSize = requiredSizePx ?? MIN_TOUCH_TARGET_SIZE_AAA;
+		return [
+			`Increase the touch target size to at least ${minSize}x${minSize} pixels to ensure better accessibility on mobile devices. Maintain adequate spacing between interactive elements.`,
+		];
+	}
+
+	const label = ISSUE_TYPE_LABELS[issueType].toLowerCase();
+	const entry = ISSUE_RECOMMENDATIONS.find((item) => item[label] !== undefined);
+	return entry ? entry[label] : null;
+}

--- a/src/lib/issuesData/index.tsx
+++ b/src/lib/issuesData/index.tsx
@@ -1,6 +1,5 @@
 import { Contrast, MoveHorizontal, Pointer, TypeOutline } from "lucide-react";
-import { MIN_FONT_SIZE } from "./constants";
-import { Issue, IssueRecommendations } from "./types";
+import { Issue } from "../types";
 
 /**
  * Node types a touch-target issue (size or spacing) can apply to. Shared
@@ -79,29 +78,4 @@ const ISSUES_DATA_SCHEMA: Issue[] = [
 	},
 ];
 
-const ISSUE_RECOMMENDATIONS: IssueRecommendations[] = [
-	{
-		contrast: [
-			"Increase the contrast ratio to at least 4.5:1 for normal text and 3:1 for large text (18px and up).",
-			"To improve contrast, use a darker text color or a lighter background color.",
-		],
-	},
-	{
-		typography: [
-			`Ensure font size is at least ${MIN_FONT_SIZE}px to enhance readability and comply with WCAG "AA" standards.`,
-			"Use a minimum font size of 16px for body text and 14px for buttons and other interactive elements.",
-		],
-	},
-	{
-		"touch target size": [
-			"Increase the touch target size to at least 44x44 pixels to ensure better accessibility on mobile devices. Maintain adequate spacing between interactive elements.",
-		],
-	},
-	{
-		"touch target spacing": [
-			"The touch target spacing should be at least 8px to the nearest element in all directions.",
-		],
-	},
-];
-
-export { ISSUE_RECOMMENDATIONS, ISSUES_DATA_SCHEMA };
+export default ISSUES_DATA_SCHEMA;

--- a/src/lib/utils/index.test.ts
+++ b/src/lib/utils/index.test.ts
@@ -6,6 +6,7 @@ import {
 	copyToClipboard,
 	getBackgroundColorForNode,
 	getContrastCompliance,
+	getContrastIssueDescription,
 	getRouteForIssueType,
 	getScanSettings,
 	getSeverityStyles,
@@ -336,6 +337,38 @@ describe("contrastFailsTargetLevel", () => {
 	it("does not flag when there is no compliance result yet", () => {
 		expect(contrastFailsTargetLevel(undefined, "AA")).toBe(false);
 		expect(contrastFailsTargetLevel(undefined, "AAA")).toBe(false);
+	});
+});
+
+describe("getContrastIssueDescription", () => {
+	it("describes a genuine AA failure the same regardless of target level", () => {
+		expect(getContrastIssueDescription("Fail", "AA")).toBe(
+			"Text contrast is below WCAG AA standard.",
+		);
+		expect(getContrastIssueDescription("Fail", "AAA")).toBe(
+			"Text contrast is below WCAG AA standard.",
+		);
+	});
+
+	it("describes an AA-passing/AAA-failing result differently when the target is AAA", () => {
+		expect(getContrastIssueDescription("AA", "AAA")).toBe(
+			"Text contrast meets WCAG AA but is below the stricter WCAG AAA standard.",
+		);
+		expect(getContrastIssueDescription("AA Large", "AAA")).toBe(
+			"Text contrast meets WCAG AA but is below the stricter WCAG AAA standard.",
+		);
+	});
+
+	it("does not describe an AA-passing result as failing when the target is AA", () => {
+		expect(getContrastIssueDescription("AA", "AA")).toBe(
+			"Text contrast meets the selected WCAG standard.",
+		);
+	});
+
+	it("does not describe an AAA-passing result as failing when the target is AAA", () => {
+		expect(getContrastIssueDescription("AAA", "AAA")).toBe(
+			"Text contrast meets the selected WCAG standard.",
+		);
 	});
 });
 

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -40,6 +40,29 @@ export function contrastFailsTargetLevel(
 	return false;
 }
 
+/**
+ * Contrast issue description text for the given compliance tier and target
+ * level - computed at render/report time rather than baked into the issue
+ * at scan time, since contrast target-level filtering is instant/client-side
+ * (toggling AA/AAA doesn't rescan) and the same stored issue is shown or
+ * exported under whichever level is currently selected. A pair that passes
+ * AA but only fails AAA (`compliance: "AA"`/`"AA Large"`) needs different
+ * copy from one that fails outright - "below WCAG AA standard" would be
+ * false for the former.
+ */
+export function getContrastIssueDescription(
+	compliance: string | undefined,
+	targetLevel: TargetLevel,
+): string {
+	if (!contrastFailsTargetLevel(compliance, targetLevel)) {
+		return "Text contrast meets the selected WCAG standard.";
+	}
+	if (compliance === "Fail") {
+		return "Text contrast is below WCAG AA standard.";
+	}
+	return "Text contrast meets WCAG AA but is below the stricter WCAG AAA standard.";
+}
+
 // Global state
 const state = {
 	IsQuickCheckModeActive: false,


### PR DESCRIPTION
## Summary
Confirmed two real instances of the same root cause, both fixed here.

- `createContrastIssue`'s `description` was a hardcoded `"Text contrast is below WCAG AA standard."`, baked in once at scan time for every text node regardless of its actual compliance tier. Contrast target-level filtering is instant/client-side (toggling AA/AAA doesn't rescan), so the same stored issue is shown under whichever level is currently selected — a node that passes AA and only fails AAA still showed "below WCAG AA standard", contradicting `IssuesNavigator` right below it.
- The static `ISSUE_RECOMMENDATIONS` lookup had the same bug class: contrast's recommendation always cited the AA ratios (4.5:1/3:1) even when an AAA-triggered failure needs 7:1/4.5:1 — literally wrong advice. Touch-target size's recommendation hardcoded "44x44 pixels" regardless of the selected level's actual required size.

**Fix**: mirror what `IssuesNavigator` already does correctly — derive this copy at render/report time from the issue's actual `contrastScore`/`requiredSizePx` and the live `targetLevel`, instead of a static string baked in at scan time or keyed only by type.

- New `getContrastIssueDescription` (`src/lib/utils`).
- New `getIssueRecommendations` (`src/lib/issueRecommendations`, new module).
- `IssuesWrapper` (in-app detail view) and `IssuesOverviewList`'s CSV/JSON export both switched to the dynamic helpers — both inherited the same root-cause bug independently, the export path wasn't in the original bug report but traces to the same static field.
- Found and fixed a latent bug along the way: `IssuesWrapper` always derived `description`/`suggestions` from `currentIssue`, never `singleIssue`, so quick-check mode's description silently never rendered at all.
- Moved `issuesData.tsx` → `issuesData/index.tsx` (folder convention, now carries real logic) and split the non-JSX recommendation logic into its own `issueRecommendations` module (avoids a Fast Refresh lint warning from mixing a function export with JSX data in one `.tsx` file).

## Test plan
- [x] 18 new/updated tests covering `getContrastIssueDescription`, `getIssueRecommendations`, and both components' dynamic derivation (including the quick-check `activeIssue` fix and the CSV/JSON export)
- [x] Mutation-tested all three key logic changes (AA/AAA description branching, AA/AAA ratio branching, the `activeIssue` fix) — confirmed each catches a real regression, restored
- [x] `tsc -b`, `npm run lint`, `npm run test` (302 passing), `npm run build` all clean