### PR TITLE
fix(a11y): hide issue-type tabs with no currently-active issues

### DIFF
--- a/src/components/organisms/IssuesOverviewList/index.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.tsx
@@ -8,10 +8,10 @@ import { IssueType, IssueX } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
 import {
 	cn,
-	contrastFailsTargetLevel,
 	getContrastIssueDescription,
 	getRouteForIssueType,
 	getSeverityStyles,
+	isActiveIssue,
 } from "@/lib/utils";
 import { saveAs } from "file-saver";
 import { ChevronLeft, ChevronRight, RefreshCcw } from "lucide-react";
@@ -35,10 +35,7 @@ export default function IssuesOverviewList() {
 
 	const issuesGroupListRecords = issues.filter((issue) => {
 		if (!issue.type || !ISSUES_TYPES.includes(issue.type)) return false;
-		if (issue.type === "CONTRAST") {
-			return contrastFailsTargetLevel(issue.nodeData.contrastScore?.compliance, targetLevel);
-		}
-		return true;
+		return isActiveIssue(issue, targetLevel);
 	});
 
 	const hasContrastIssues = issues.some((issue) => issue.type === "CONTRAST");

--- a/src/components/organisms/IssuesWrapper/index.test.tsx
+++ b/src/components/organisms/IssuesWrapper/index.test.tsx
@@ -187,6 +187,23 @@ describe("IssuesWrapper", () => {
 		expect(useIssuesStore.getState().currentRoute).toBe("TOUCH_TARGET_ISSUE_LIST_VIEW");
 	});
 
+	it("does not show a Contrast tab when the only contrast issues present aren't currently failing", async () => {
+		useIssuesStore.setState({
+			selectedType: "TOUCH_TARGET_SIZE",
+			issues: [touchTargetIssue, contrastAaOnlyIssue],
+			targetLevel: "AA",
+		});
+		const { rerender } = render(<IssuesWrapper>child</IssuesWrapper>);
+
+		expect(screen.queryByRole("tablist")).toBeNull();
+		expect(screen.queryByRole("tab", { name: "Switch to Contrast issues" })).toBeNull();
+
+		useIssuesStore.setState({ targetLevel: "AAA" });
+		rerender(<IssuesWrapper>child</IssuesWrapper>);
+
+		expect(screen.getByRole("tab", { name: "Switch to Contrast issues" })).toBeVisible();
+	});
+
 	it("shows the detection-info popover for types that have tooltip copy, not for TYPOGRAPHY", () => {
 		useIssuesStore.setState({ selectedType: "CONTRAST" });
 		const { rerender } = render(<IssuesWrapper>child</IssuesWrapper>);

--- a/src/components/organisms/IssuesWrapper/index.tsx
+++ b/src/components/organisms/IssuesWrapper/index.tsx
@@ -9,7 +9,7 @@ import getIssueRecommendations from "@/lib/issueRecommendations";
 import ISSUES_DATA_SCHEMA from "@/lib/issuesData";
 import { IssueType, IssueX } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
-import { cn, getContrastIssueDescription, getRouteForIssueType } from "@/lib/utils";
+import { cn, getContrastIssueDescription, getRouteForIssueType, isActiveIssue } from "@/lib/utils";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -136,8 +136,15 @@ export default function IssuesWrapper({ children }: { children: React.ReactNode 
 	// them from an issue that isn't the one on screen.
 	const activeIssue = issueGroupList.length === 0 ? singleIssue : currentIssue;
 	const { type } = activeIssue || {};
-	const availableTypes = ISSUES_DATA_SCHEMA.filter((issue) =>
-		issues.some((i) => i.type === issue.type),
+	// issues.some((i) => i.type === issue.type) alone isn't enough here - every
+	// scanned text node gets a CONTRAST issue object regardless of whether it
+	// currently passes (see isActiveIssue), so the Contrast tab would show up
+	// whenever the page has any text at all, even with zero currently-failing
+	// contrast issues.
+	const availableTypes = ISSUES_DATA_SCHEMA.filter((schemaIssue) =>
+		issues.some(
+			(issue) => issue.type === schemaIssue.type && isActiveIssue(issue, targetLevel),
+		),
 	);
 	const selectedTypeLabel = selectedType ? ISSUE_TYPE_LABELS[selectedType] : "";
 	const currentOrSelectedType = type ?? selectedType;

--- a/src/lib/useIssuesStore/index.ts
+++ b/src/lib/useIssuesStore/index.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { MESSAGE_TYPES } from "../constants";
 import { postMessageToBackend } from "../figmaUtils";
 import { DeviceType, EnhancedIssuesStore, IssueType, IssueX, Routes, TargetLevel } from "../types";
-import { contrastFailsTargetLevel } from "../utils";
+import { isActiveIssue } from "../utils";
 
 const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
 	issues: [],
@@ -49,18 +49,9 @@ const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
 	getIssueGroupList: () => {
 		const { issues, selectedType, targetLevel } = get();
 
-		const response = issues.filter((issue) => {
-			if (issue.type && issue.type === selectedType) {
-				if (issue.type === "CONTRAST") {
-					return contrastFailsTargetLevel(
-						issue.nodeData.contrastScore?.compliance,
-						targetLevel,
-					);
-				}
-				return true;
-			}
-			return false;
-		});
+		const response = issues.filter(
+			(issue) => issue.type === selectedType && isActiveIssue(issue, targetLevel),
+		);
 
 		return response;
 	},

--- a/src/lib/utils/index.test.ts
+++ b/src/lib/utils/index.test.ts
@@ -10,9 +10,11 @@ import {
 	getRouteForIssueType,
 	getScanSettings,
 	getSeverityStyles,
+	isActiveIssue,
 	isBoldFont,
 	setScanSettings,
 } from "./index";
+import { IssueX } from "@/lib/types";
 
 const WHITE: RGBColor = [255, 255, 255];
 const BLACK: RGBColor = [0, 0, 0];
@@ -369,6 +371,50 @@ describe("getContrastIssueDescription", () => {
 		expect(getContrastIssueDescription("AAA", "AAA")).toBe(
 			"Text contrast meets the selected WCAG standard.",
 		);
+	});
+});
+
+function fakeContrastIssue(compliance: string): IssueX {
+	return {
+		type: "CONTRAST",
+		severity: "critical",
+		nodeData: {
+			id: "c1",
+			name: "Text",
+			nodeType: "TEXT",
+			contrastScore: { compliance, ratio: 5 },
+		},
+	};
+}
+
+describe("isActiveIssue", () => {
+	it("is always active for non-contrast issue types, regardless of target level", () => {
+		const typographyIssue: IssueX = {
+			type: "TYPOGRAPHY",
+			severity: "major",
+			nodeData: { id: "t1", name: "Label", nodeType: "TEXT" },
+		};
+
+		expect(isActiveIssue(typographyIssue, "AA")).toBe(true);
+		expect(isActiveIssue(typographyIssue, "AAA")).toBe(true);
+	});
+
+	it("is active for a genuinely failing contrast issue at any target level", () => {
+		expect(isActiveIssue(fakeContrastIssue("Fail"), "AA")).toBe(true);
+		expect(isActiveIssue(fakeContrastIssue("Fail"), "AAA")).toBe(true);
+	});
+
+	it("is not active for an AA-passing contrast issue when the target is AA", () => {
+		expect(isActiveIssue(fakeContrastIssue("AA"), "AA")).toBe(false);
+	});
+
+	it("is active for an AA-passing/AAA-failing contrast issue only when the target is AAA", () => {
+		expect(isActiveIssue(fakeContrastIssue("AA"), "AAA")).toBe(true);
+	});
+
+	it("is not active for an AAA-passing contrast issue at any target level", () => {
+		expect(isActiveIssue(fakeContrastIssue("AAA"), "AA")).toBe(false);
+		expect(isActiveIssue(fakeContrastIssue("AAA"), "AAA")).toBe(false);
 	});
 });
 

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,7 +1,7 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { rgb, RGBColor, score } from "wcag-contrast";
-import { copyToClipboardProps, DeviceType, IssueType, Routes, TargetLevel } from "../types";
+import { copyToClipboardProps, DeviceType, IssueType, IssueX, Routes, TargetLevel } from "../types";
 
 export function cn(...inputs: ClassValue[]) {
 	// eslint-disable-next-line tailwindcss/no-custom-classname -- false positive: the plugin treats the `inputs` variable reference as if it were a classname string literal.
@@ -61,6 +61,24 @@ export function getContrastIssueDescription(
 		return "Text contrast is below WCAG AA standard.";
 	}
 	return "Text contrast meets WCAG AA but is below the stricter WCAG AAA standard.";
+}
+
+/**
+ * Whether an issue currently counts as an active issue at the given target
+ * level. `analyzeTextNodeForContrastIssue` pushes a CONTRAST issue object
+ * for every scanned text node with a resolvable background, regardless of
+ * whether it currently passes - `getContrastCompliance` always returns a
+ * compliance tier, never null. So raw presence of a CONTRAST issue in
+ * `issues` doesn't mean it's actually failing right now;
+ * `contrastFailsTargetLevel` is the source of truth for that. Every other
+ * issue type's pass/fail state is fixed at scan time, so it's always active
+ * once present.
+ */
+export function isActiveIssue(issue: IssueX, targetLevel: TargetLevel): boolean {
+	if (issue.type === "CONTRAST") {
+		return contrastFailsTargetLevel(issue.nodeData.contrastScore?.compliance, targetLevel);
+	}
+	return true;
 }
 
 // Global state


### PR DESCRIPTION
## Summary
User-reported: the quick-switch tab row in the issue detail pager showed a Contrast tab even when the currently-selected WCAG level had zero failing contrast issues — clicking into it landed on "No Contrast issue detected".

**Root cause**: `analyzeTextNodeForContrastIssue` pushes a `CONTRAST` issue object for every scanned text node with a resolvable background, pass or fail alike — `getContrastCompliance` always returns a compliance tier, never `null`. That's deliberate: it's what makes the AA/AAA toggle instant with no rescan (#43). But it also means raw presence of a `CONTRAST` entry in `issues` doesn't mean it's currently failing. `IssuesWrapper`'s `availableTypes` only checked raw presence, so the tab stayed visible behind an already-passing, "phantom" issue.

**Fix**: new shared `isActiveIssue` (`src/lib/utils`) is the single source of truth for "does this issue currently count, at this target level" — used consistently by:
- `IssuesWrapper.availableTypes` (the actual reported bug)
- `useIssuesStore.getIssueGroupList` (already had its own copy of the same CONTRAST-only check inline)
- `IssuesOverviewList.issuesGroupListRecords` (same, already correct, now deduped too)

Every non-`CONTRAST` issue type is always active once present — confirmed by reading `collectTouchTargetIssues`/`createTypographyIssue`, not assumed: those only ever push an issue on genuine failure at scan time, so they never produce a phantom entry the way Contrast's always-created-regardless-of-pass/fail design does. The fix is applied uniformly across all issue types via the shared helper, not special-cased to Contrast in the filter logic itself.

## Test plan
- [x] New test reproducing the exact reported scenario: a page with a Touch Target Size issue and an AA-passing Contrast issue at AA target level shows no tab switcher / no Contrast tab; switching to AAA (where that contrast pair now fails) makes the Contrast tab appear
- [x] New `isActiveIssue` unit tests (non-contrast always active, genuine Fail always active, AA-passing/AAA-failing active only at AAA, AAA-passing never active)
- [x] Mutation-tested `isActiveIssue` (stubbed to always return `true`) — confirmed it breaks 10 tests across all 4 consumer files simultaneously (utils, `IssuesWrapper`, `IssuesOverviewList`, `useIssuesStore`), then restored
- [x] `tsc -b`, `npm run lint`, `npm run test` (308 passing), `npm run build` all clean