### PR TITLE
refactor: rename IssueX/issues store fields to DetectedIssue/detectedIssues

### DIFF
--- a/plugin/code.ts
+++ b/plugin/code.ts
@@ -11,7 +11,7 @@ import {
 	isScannable,
 } from "@/lib/figmaUtils/collectIssues";
 import generateAltTextForLayer from "@/lib/helpers/generateAltTextForLayer";
-import { DeviceType, IssueX, TargetLevel } from "@/lib/types";
+import { DeviceType, DetectedIssue, TargetLevel } from "@/lib/types";
 import {
 	figmaRGBtoHex,
 	getIsQuickCheckModeActive,
@@ -165,7 +165,7 @@ async function handleScan(message: ScanSettings) {
 	// ) as VectorNode[];
 	const allPageNodes = figma.currentPage.findAll((node) => isScannable(node)) as SceneNode[];
 
-	const issues: IssueX[] = await collectIssues(
+	const issues: DetectedIssue[] = await collectIssues(
 		allTextNodes,
 		allPageNodes,
 		deviceType,

--- a/src/components/organisms/IssuesNavigator/index.test.tsx
+++ b/src/components/organisms/IssuesNavigator/index.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MESSAGE_TYPES } from "@/lib/constants";
-import { IssueX } from "@/lib/types";
+import { DetectedIssue } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
 
 const { postMessageToBackend } = vi.hoisted(() => ({
@@ -17,7 +17,7 @@ vi.mock("@/components/organisms/IssuesWrapper", () => ({
 
 import IssuesNavigator from "./index";
 
-const typographyIssue: IssueX = {
+const typographyIssue: DetectedIssue = {
 	type: "TYPOGRAPHY",
 	description: "Text size is too small for readability.",
 	severity: "major",
@@ -30,7 +30,7 @@ const typographyIssue: IssueX = {
 	},
 };
 
-const contrastIssue: IssueX = {
+const contrastIssue: DetectedIssue = {
 	type: "CONTRAST",
 	description: "Text contrast is below WCAG AA standard.",
 	severity: "critical",
@@ -47,16 +47,16 @@ const contrastIssue: IssueX = {
 };
 
 const defaultState = {
-	issues: [] as IssueX[],
+	detectedIssues: [] as DetectedIssue[],
 	singleIssue: null,
-	currentIndex: 0,
+	currentIssueIndex: 0,
 	selectedType: "" as const,
 	targetLevel: "AA" as const,
 };
 
 // #767676 on white is the commonly-cited "AA minimum grey" reference pair -
 // 4.54:1, clears AA's 4.5 but not AAA's 7 for normal-size text.
-const aaPassingAaaFailingContrastIssue: IssueX = {
+const aaPassingAaaFailingContrastIssue: DetectedIssue = {
 	...contrastIssue,
 	nodeData: {
 		...contrastIssue.nodeData,
@@ -83,7 +83,7 @@ describe("IssuesNavigator", () => {
 	it("renders the text, font size, and severity rows for a typography issue", () => {
 		useIssuesStore.setState({
 			selectedType: "TYPOGRAPHY",
-			issues: [typographyIssue],
+			detectedIssues: [typographyIssue],
 		});
 		render(<IssuesNavigator />);
 
@@ -96,7 +96,7 @@ describe("IssuesNavigator", () => {
 		const user = userEvent.setup();
 		useIssuesStore.setState({
 			selectedType: "TYPOGRAPHY",
-			issues: [typographyIssue],
+			detectedIssues: [typographyIssue],
 		});
 		render(<IssuesNavigator />);
 
@@ -108,14 +108,14 @@ describe("IssuesNavigator", () => {
 			id: "t1",
 			fontSize: 18,
 		});
-		expect(useIssuesStore.getState().issues[0].nodeData.fontSize).toBe(18);
+		expect(useIssuesStore.getState().detectedIssues[0].nodeData.fontSize).toBe(18);
 	});
 
 	it("updates singleIssue instead of the issues list when there is no active issue group (quick check mode)", async () => {
 		const user = userEvent.setup();
 		useIssuesStore.setState({
 			selectedType: "TYPOGRAPHY",
-			issues: [],
+			detectedIssues: [],
 			singleIssue: typographyIssue,
 		});
 		render(<IssuesNavigator />);
@@ -130,7 +130,7 @@ describe("IssuesNavigator", () => {
 	it("shows the contrast-specific rows only for a CONTRAST issue", () => {
 		useIssuesStore.setState({
 			selectedType: "CONTRAST",
-			issues: [contrastIssue],
+			detectedIssues: [contrastIssue],
 		});
 		render(<IssuesNavigator />);
 
@@ -145,7 +145,7 @@ describe("IssuesNavigator", () => {
 	it("does not show the contrast-specific rows for a non-CONTRAST issue", () => {
 		useIssuesStore.setState({
 			selectedType: "TYPOGRAPHY",
-			issues: [typographyIssue],
+			detectedIssues: [typographyIssue],
 		});
 		render(<IssuesNavigator />);
 
@@ -164,7 +164,7 @@ describe("IssuesNavigator", () => {
 		it("does not render for a non-CONTRAST issue", () => {
 			useIssuesStore.setState({
 				selectedType: "TYPOGRAPHY",
-				issues: [typographyIssue],
+				detectedIssues: [typographyIssue],
 			});
 			render(<IssuesNavigator />);
 
@@ -174,7 +174,7 @@ describe("IssuesNavigator", () => {
 		it("does not render when the contrast check isn't failing", () => {
 			useIssuesStore.setState({
 				selectedType: "CONTRAST",
-				issues: [
+				detectedIssues: [
 					{
 						...contrastIssue,
 						nodeData: {
@@ -192,7 +192,7 @@ describe("IssuesNavigator", () => {
 		it("renders for an AA-passing/AAA-failing issue once the detection target level is AAA", () => {
 			useIssuesStore.setState({
 				selectedType: "CONTRAST",
-				issues: [aaPassingAaaFailingContrastIssue],
+				detectedIssues: [aaPassingAaaFailingContrastIssue],
 				targetLevel: "AAA",
 			});
 			render(<IssuesNavigator />);
@@ -204,7 +204,7 @@ describe("IssuesNavigator", () => {
 		it("still does not render an AA-passing/AAA-failing issue while the detection target level is AA", () => {
 			useIssuesStore.setState({
 				selectedType: "CONTRAST",
-				issues: [aaPassingAaaFailingContrastIssue],
+				detectedIssues: [aaPassingAaaFailingContrastIssue],
 				targetLevel: "AA",
 			});
 			render(<IssuesNavigator />);
@@ -215,7 +215,7 @@ describe("IssuesNavigator", () => {
 		it("suggests darkening text that's the lighter of the two colours", () => {
 			useIssuesStore.setState({
 				selectedType: "CONTRAST",
-				issues: [
+				detectedIssues: [
 					{
 						...contrastIssue,
 						nodeData: {
@@ -236,7 +236,7 @@ describe("IssuesNavigator", () => {
 		it("suggests lightening text that's already the darker of the two colours", () => {
 			useIssuesStore.setState({
 				selectedType: "CONTRAST",
-				issues: [
+				detectedIssues: [
 					{
 						...contrastIssue,
 						nodeData: {
@@ -256,7 +256,7 @@ describe("IssuesNavigator", () => {
 			const user = userEvent.setup();
 			useIssuesStore.setState({
 				selectedType: "CONTRAST",
-				issues: [
+				detectedIssues: [
 					{
 						...contrastIssue,
 						nodeData: {
@@ -279,7 +279,7 @@ describe("IssuesNavigator", () => {
 		it("discloses when the suggested background is shared with other layers", () => {
 			useIssuesStore.setState({
 				selectedType: "CONTRAST",
-				issues: [
+				detectedIssues: [
 					{
 						...contrastIssue,
 						nodeData: {
@@ -297,7 +297,7 @@ describe("IssuesNavigator", () => {
 		it("omits the disclosure when the background isn't shared with anything else", () => {
 			useIssuesStore.setState({
 				selectedType: "CONTRAST",
-				issues: [contrastIssue],
+				detectedIssues: [contrastIssue],
 			});
 			render(<IssuesNavigator />);
 
@@ -308,7 +308,7 @@ describe("IssuesNavigator", () => {
 			const user = userEvent.setup();
 			useIssuesStore.setState({
 				selectedType: "CONTRAST",
-				issues: [
+				detectedIssues: [
 					{
 						...contrastIssue,
 						nodeData: {
@@ -332,7 +332,7 @@ describe("IssuesNavigator", () => {
 			const user = userEvent.setup();
 			useIssuesStore.setState({
 				selectedType: "CONTRAST",
-				issues: [
+				detectedIssues: [
 					{
 						...contrastIssue,
 						nodeData: {
@@ -363,7 +363,7 @@ describe("IssuesNavigator", () => {
 
 			const updatedIssue = useIssuesStore
 				.getState()
-				.issues.find((issue) => issue.nodeData.id === "c1");
+				.detectedIssues.find((issue) => issue.nodeData.id === "c1");
 			expect(updatedIssue?.nodeData.contrastScore?.compliance).not.toBe("Fail");
 			expect(screen.queryByText("Suggested fixes")).toBeNull();
 		});
@@ -372,7 +372,7 @@ describe("IssuesNavigator", () => {
 			const user = userEvent.setup();
 			useIssuesStore.setState({
 				selectedType: "CONTRAST",
-				issues: [
+				detectedIssues: [
 					{
 						...contrastIssue,
 						nodeData: {
@@ -405,7 +405,7 @@ describe("IssuesNavigator", () => {
 			const user = userEvent.setup();
 			useIssuesStore.setState({
 				selectedType: "CONTRAST",
-				issues: [
+				detectedIssues: [
 					{
 						...contrastIssue,
 						nodeData: {
@@ -431,7 +431,7 @@ describe("IssuesNavigator", () => {
 			const user = userEvent.setup();
 			useIssuesStore.setState({
 				selectedType: "CONTRAST",
-				issues: [
+				detectedIssues: [
 					{
 						...contrastIssue,
 						nodeData: {
@@ -461,7 +461,7 @@ describe("IssuesNavigator", () => {
 			const user = userEvent.setup();
 			useIssuesStore.setState({
 				selectedType: "CONTRAST",
-				issues: [
+				detectedIssues: [
 					{
 						...contrastIssue,
 						nodeData: {

--- a/src/components/organisms/IssuesNavigator/index.tsx
+++ b/src/components/organisms/IssuesNavigator/index.tsx
@@ -5,7 +5,7 @@ import Input from "@/components/ui/input";
 import { ColorFixDirection, ColorFixSuggestion, suggestAccessibleColor } from "@/lib/colorFix";
 import { MESSAGE_TYPES, MIN_FONT_SIZE } from "@/lib/constants";
 import { postMessageToBackend } from "@/lib/figmaUtils";
-import { IssueX, TargetLevel } from "@/lib/types";
+import { DetectedIssue, TargetLevel } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
 import {
 	cn,
@@ -19,7 +19,7 @@ import { useState } from "react";
 
 export default function IssuesNavigator() {
 	const {
-		currentIndex,
+		currentIssueIndex,
 		singleIssue,
 		selectedType,
 		updateIssue,
@@ -38,8 +38,8 @@ export default function IssuesNavigator() {
 	// one the user was told is failing, not always the least strict one.
 	const [targetLevel, setTargetLevel] = useState<TargetLevel>(detectionTargetLevel);
 
-	const issueGroupList: IssueX[] = getIssueGroupList();
-	const currentIssue: IssueX = issueGroupList[currentIndex] ?? {};
+	const issueGroupList: DetectedIssue[] = getIssueGroupList();
+	const currentIssue: DetectedIssue = issueGroupList[currentIssueIndex] ?? {};
 
 	const handleFontSizeChange = (id: string, value: string, isSingleIssue: boolean = false) => {
 		const newSize = Number(value);

--- a/src/components/organisms/IssuesOverviewList/index.test.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MESSAGE_TYPES } from "@/lib/constants";
-import { IssueX } from "@/lib/types";
+import { DetectedIssue } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
 
 const { postMessageToBackend } = vi.hoisted(() => ({
@@ -25,14 +25,14 @@ async function goToReportTab(user: ReturnType<typeof userEvent.setup>) {
 	await user.click(screen.getByRole("tab", { name: "Report" }));
 }
 
-const typographyIssue: IssueX = {
+const typographyIssue: DetectedIssue = {
 	type: "TYPOGRAPHY",
 	description: "Text size is too small for readability.",
 	severity: "major",
 	nodeData: { id: "t1", name: "Label", nodeType: "TEXT" },
 };
 
-const contrastFailIssue: IssueX = {
+const contrastFailIssue: DetectedIssue = {
 	type: "CONTRAST",
 	description: "Text contrast is below WCAG AA standard.",
 	severity: "critical",
@@ -44,7 +44,7 @@ const contrastFailIssue: IssueX = {
 	},
 };
 
-const contrastPassIssue: IssueX = {
+const contrastPassIssue: DetectedIssue = {
 	...contrastFailIssue,
 	nodeData: {
 		...contrastFailIssue.nodeData,
@@ -54,7 +54,7 @@ const contrastPassIssue: IssueX = {
 };
 
 const defaultState = {
-	issues: [] as IssueX[],
+	detectedIssues: [] as DetectedIssue[],
 	scanning: false,
 	currentRoute: "INDEX" as const,
 	selectedType: "" as const,
@@ -85,7 +85,7 @@ describe("IssuesOverviewList", () => {
 		dispatch(MESSAGE_TYPES.LOAD_ISSUES, [typographyIssue]);
 
 		expect(useIssuesStore.getState().scanning).toBe(false);
-		expect(useIssuesStore.getState().issues).toEqual([typographyIssue]);
+		expect(useIssuesStore.getState().detectedIssues).toEqual([typographyIssue]);
 	});
 
 	it("logs an error and ignores a malformed message", () => {
@@ -95,25 +95,25 @@ describe("IssuesOverviewList", () => {
 		window.dispatchEvent(new MessageEvent("message", { data: null }));
 
 		expect(errorSpy).toHaveBeenCalledWith("Invalid message format:", null);
-		expect(useIssuesStore.getState().issues).toEqual([]);
+		expect(useIssuesStore.getState().detectedIssues).toEqual([]);
 
 		errorSpy.mockRestore();
 	});
 
 	it("returns to the index and clears issues when the back button is clicked", async () => {
 		const user = userEvent.setup();
-		useIssuesStore.setState({ issues: [typographyIssue] });
+		useIssuesStore.setState({ detectedIssues: [typographyIssue] });
 		render(<IssuesOverviewList />);
 
 		await user.click(screen.getByRole("button", { name: "Back" }));
 
 		expect(useIssuesStore.getState().currentRoute).toBe("INDEX");
-		expect(useIssuesStore.getState().issues).toEqual([]);
+		expect(useIssuesStore.getState().detectedIssues).toEqual([]);
 	});
 
 	it("rescans by clearing issues and starting a new scan", async () => {
 		const user = userEvent.setup();
-		useIssuesStore.setState({ issues: [typographyIssue] });
+		useIssuesStore.setState({ detectedIssues: [typographyIssue] });
 		render(<IssuesOverviewList />);
 
 		await user.click(screen.getByRole("button", { name: "Rescan for issues" }));
@@ -134,7 +134,7 @@ describe("IssuesOverviewList", () => {
 	it("lists each present issue type with its count and only counts failing contrast issues", async () => {
 		const user = userEvent.setup();
 		useIssuesStore.setState({
-			issues: [typographyIssue, contrastFailIssue, contrastPassIssue],
+			detectedIssues: [typographyIssue, contrastFailIssue, contrastPassIssue],
 		});
 		render(<IssuesOverviewList />);
 
@@ -150,7 +150,7 @@ describe("IssuesOverviewList", () => {
 	});
 
 	it("does not show the WCAG target toggle when there are no contrast issues", () => {
-		useIssuesStore.setState({ issues: [typographyIssue] });
+		useIssuesStore.setState({ detectedIssues: [typographyIssue] });
 		render(<IssuesOverviewList />);
 
 		expect(screen.queryByText("WCAG target")).toBeNull();
@@ -158,7 +158,7 @@ describe("IssuesOverviewList", () => {
 
 	it("shows the WCAG target toggle when there are contrast issues, defaulting to AA", () => {
 		useIssuesStore.setState({
-			issues: [contrastFailIssue, contrastPassIssue],
+			detectedIssues: [contrastFailIssue, contrastPassIssue],
 		});
 		render(<IssuesOverviewList />);
 
@@ -169,7 +169,7 @@ describe("IssuesOverviewList", () => {
 	it("counts an AA-passing contrast issue as failing once the target level is switched to AAA", async () => {
 		const user = userEvent.setup();
 		useIssuesStore.setState({
-			issues: [contrastFailIssue, contrastPassIssue],
+			detectedIssues: [contrastFailIssue, contrastPassIssue],
 		});
 		render(<IssuesOverviewList />);
 
@@ -183,7 +183,7 @@ describe("IssuesOverviewList", () => {
 
 	it("shows the category breakdown chart on the Report tab only when there are counted issues", async () => {
 		const user = userEvent.setup();
-		useIssuesStore.setState({ issues: [typographyIssue] });
+		useIssuesStore.setState({ detectedIssues: [typographyIssue] });
 		render(<IssuesOverviewList />);
 
 		await goToReportTab(user);
@@ -193,7 +193,7 @@ describe("IssuesOverviewList", () => {
 
 	it("does not show the breakdown chart when there are no counted issues", async () => {
 		const user = userEvent.setup();
-		useIssuesStore.setState({ issues: [contrastPassIssue] });
+		useIssuesStore.setState({ detectedIssues: [contrastPassIssue] });
 		render(<IssuesOverviewList />);
 
 		await goToReportTab(user);
@@ -203,7 +203,7 @@ describe("IssuesOverviewList", () => {
 
 	it("downloads a CSV report when 'Download CSV' is clicked", async () => {
 		const user = userEvent.setup();
-		useIssuesStore.setState({ issues: [typographyIssue] });
+		useIssuesStore.setState({ detectedIssues: [typographyIssue] });
 		render(<IssuesOverviewList />);
 
 		await goToReportTab(user);
@@ -214,7 +214,7 @@ describe("IssuesOverviewList", () => {
 
 	it("downloads a JSON report when 'Download JSON' is clicked", async () => {
 		const user = userEvent.setup();
-		useIssuesStore.setState({ issues: [typographyIssue] });
+		useIssuesStore.setState({ detectedIssues: [typographyIssue] });
 		render(<IssuesOverviewList />);
 
 		await goToReportTab(user);
@@ -225,7 +225,7 @@ describe("IssuesOverviewList", () => {
 
 	it("exports a target-level-aware contrast description, not the stale 'below WCAG AA standard' text", async () => {
 		const user = userEvent.setup();
-		useIssuesStore.setState({ issues: [contrastPassIssue], targetLevel: "AAA" });
+		useIssuesStore.setState({ detectedIssues: [contrastPassIssue], targetLevel: "AAA" });
 		render(<IssuesOverviewList />);
 
 		await goToReportTab(user);

--- a/src/components/organisms/IssuesOverviewList/index.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.tsx
@@ -4,7 +4,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ISSUES_TYPES, MESSAGE_TYPES } from "@/lib/constants";
 import ISSUE_TYPE_LABELS from "@/lib/issueTypeLabels";
 import ISSUES_DATA_SCHEMA from "@/lib/issuesData";
-import { IssueType, IssueX } from "@/lib/types";
+import { IssueType, DetectedIssue } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
 import {
 	cn,
@@ -23,8 +23,8 @@ import LoadingScreen from "@/components/organisms/LoadingScreen";
 export default function IssuesOverviewList() {
 	const {
 		scanning,
-		issues,
-		setIssues,
+		detectedIssues,
+		setDetectedIssues,
 		setScanning,
 		setSelectedType,
 		navigateTo,
@@ -33,12 +33,12 @@ export default function IssuesOverviewList() {
 		setTargetLevel,
 	} = useIssuesStore();
 
-	const issuesGroupListRecords = issues.filter((issue) => {
+	const issuesGroupListRecords = detectedIssues.filter((issue) => {
 		if (!issue.type || !ISSUES_TYPES.includes(issue.type)) return false;
 		return isActiveIssue(issue, targetLevel);
 	});
 
-	const hasContrastIssues = issues.some((issue) => issue.type === "CONTRAST");
+	const hasContrastIssues = detectedIssues.some((issue) => issue.type === "CONTRAST");
 
 	// Listen for messages from the backend
 	useEffect(() => {
@@ -51,7 +51,7 @@ export default function IssuesOverviewList() {
 			const { type, data } = event.data.pluginMessage;
 
 			if (type === MESSAGE_TYPES.LOAD_ISSUES) {
-				setIssues(data);
+				setDetectedIssues(data);
 				setScanning(false);
 			}
 		};
@@ -61,7 +61,7 @@ export default function IssuesOverviewList() {
 		return () => {
 			window.removeEventListener("message", handleMessage);
 		};
-	}, [setIssues, setScanning]);
+	}, [setDetectedIssues, setScanning]);
 
 	const handleIssuesListClick = (type: IssueType) => {
 		setSelectedType(type);
@@ -69,7 +69,7 @@ export default function IssuesOverviewList() {
 	};
 
 	const issuesGroup = ISSUES_DATA_SCHEMA.filter((issue) =>
-		issues?.some((i: IssueX) => i.type === issue.type),
+		detectedIssues?.some((i: DetectedIssue) => i.type === issue.type),
 	);
 
 	const breakdownItems = issuesGroup
@@ -160,7 +160,7 @@ export default function IssuesOverviewList() {
 							className="w-fit! gap-0.5 group-hover:text-accent"
 							onClick={() => {
 								navigateTo("INDEX");
-								setIssues([]);
+								setDetectedIssues([]);
 							}}
 						>
 							<ChevronLeft
@@ -216,7 +216,7 @@ export default function IssuesOverviewList() {
 
 						<TabsContent value="issues">
 							<h3
-								className={`text-base font-medium tracking-wide text-grey ${issues.length > 0 ? "mb-1" : "mb-4"}`}
+								className={`text-base font-medium tracking-wide text-grey ${detectedIssues.length > 0 ? "mb-1" : "mb-4"}`}
 							>
 								Identified Issues
 							</h3>
@@ -232,7 +232,7 @@ export default function IssuesOverviewList() {
 								<ul className="space-y-2 last:mb-5!">
 									{issuesGroup.map((issue) => {
 										const issueCount = issuesGroupListRecords.filter(
-											(i: IssueX) => i.type === issue.type,
+											(i: DetectedIssue) => i.type === issue.type,
 										).length;
 
 										// Skip rendering if the issueCount is zero

--- a/src/components/organisms/IssuesWrapper/index.test.tsx
+++ b/src/components/organisms/IssuesWrapper/index.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MESSAGE_TYPES } from "@/lib/constants";
-import { IssueX } from "@/lib/types";
+import { DetectedIssue } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
 
 const { postMessageToBackend } = vi.hoisted(() => ({
@@ -17,14 +17,14 @@ function dispatch(type: string, data: unknown) {
 	window.dispatchEvent(new MessageEvent("message", { data: { pluginMessage: { type, data } } }));
 }
 
-const typographyIssue: IssueX = {
+const typographyIssue: DetectedIssue = {
 	type: "TYPOGRAPHY",
 	description: "Text size is too small for readability.",
 	severity: "major",
 	nodeData: { id: "t1", name: "Label", nodeType: "TEXT" },
 };
 
-const touchTargetIssue: IssueX = {
+const touchTargetIssue: DetectedIssue = {
 	type: "TOUCH_TARGET_SIZE",
 	description: "Touch target size is too small for accessibility.",
 	severity: "minor",
@@ -37,7 +37,7 @@ const touchTargetIssue: IssueX = {
 	},
 };
 
-const contrastFailIssue: IssueX = {
+const contrastFailIssue: DetectedIssue = {
 	type: "CONTRAST",
 	severity: "critical",
 	nodeData: {
@@ -48,7 +48,7 @@ const contrastFailIssue: IssueX = {
 	},
 };
 
-const contrastAaOnlyIssue: IssueX = {
+const contrastAaOnlyIssue: DetectedIssue = {
 	...contrastFailIssue,
 	nodeData: {
 		...contrastFailIssue.nodeData,
@@ -58,9 +58,9 @@ const contrastAaOnlyIssue: IssueX = {
 };
 
 const defaultState = {
-	issues: [] as IssueX[],
+	detectedIssues: [] as DetectedIssue[],
 	singleIssue: null,
-	currentIndex: 0,
+	currentIssueIndex: 0,
 	currentRoute: "INDEX" as const,
 	selectedType: "" as const,
 	targetLevel: "AA" as const,
@@ -146,7 +146,7 @@ describe("IssuesWrapper", () => {
 		const user = userEvent.setup();
 		useIssuesStore.setState({
 			selectedType: "TYPOGRAPHY",
-			issues: [
+			detectedIssues: [
 				typographyIssue,
 				{
 					...typographyIssue,
@@ -169,13 +169,13 @@ describe("IssuesWrapper", () => {
 		const user = userEvent.setup();
 		useIssuesStore.setState({
 			selectedType: "TYPOGRAPHY",
-			issues: [typographyIssue],
+			detectedIssues: [typographyIssue],
 		});
 		const { rerender } = render(<IssuesWrapper>child</IssuesWrapper>);
 
 		expect(screen.queryByRole("tablist")).toBeNull();
 
-		useIssuesStore.setState({ issues: [typographyIssue, touchTargetIssue] });
+		useIssuesStore.setState({ detectedIssues: [typographyIssue, touchTargetIssue] });
 		rerender(<IssuesWrapper>child</IssuesWrapper>);
 
 		const tablist = screen.getByRole("tablist", { name: "Switch issue type" });
@@ -190,7 +190,7 @@ describe("IssuesWrapper", () => {
 	it("does not show a Contrast tab when the only contrast issues present aren't currently failing", async () => {
 		useIssuesStore.setState({
 			selectedType: "TOUCH_TARGET_SIZE",
-			issues: [touchTargetIssue, contrastAaOnlyIssue],
+			detectedIssues: [touchTargetIssue, contrastAaOnlyIssue],
 			targetLevel: "AA",
 		});
 		const { rerender } = render(<IssuesWrapper>child</IssuesWrapper>);
@@ -217,7 +217,7 @@ describe("IssuesWrapper", () => {
 	it("renders the issue description, children, and recommendations once an issue is present", () => {
 		useIssuesStore.setState({
 			selectedType: "TYPOGRAPHY",
-			issues: [typographyIssue],
+			detectedIssues: [typographyIssue],
 		});
 		render(<IssuesWrapper>Row content</IssuesWrapper>);
 
@@ -229,7 +229,7 @@ describe("IssuesWrapper", () => {
 	it("describes a genuine AA contrast failure as below WCAG AA standard", () => {
 		useIssuesStore.setState({
 			selectedType: "CONTRAST",
-			issues: [contrastFailIssue],
+			detectedIssues: [contrastFailIssue],
 			targetLevel: "AA",
 		});
 		render(<IssuesWrapper>child</IssuesWrapper>);
@@ -240,7 +240,7 @@ describe("IssuesWrapper", () => {
 	it("describes an AA-passing/AAA-failing issue without falsely claiming it fails AA", () => {
 		useIssuesStore.setState({
 			selectedType: "CONTRAST",
-			issues: [contrastAaOnlyIssue],
+			detectedIssues: [contrastAaOnlyIssue],
 			targetLevel: "AAA",
 		});
 		render(<IssuesWrapper>child</IssuesWrapper>);
@@ -257,7 +257,7 @@ describe("IssuesWrapper", () => {
 		const user = userEvent.setup();
 		useIssuesStore.setState({
 			selectedType: "CONTRAST",
-			issues: [contrastAaOnlyIssue],
+			detectedIssues: [contrastAaOnlyIssue],
 			targetLevel: "AAA",
 		});
 		render(<IssuesWrapper>child</IssuesWrapper>);
@@ -270,7 +270,7 @@ describe("IssuesWrapper", () => {
 	it("shows the description for a quick-check singleIssue even though issueGroupList is empty", () => {
 		useIssuesStore.setState({
 			selectedType: "TYPOGRAPHY",
-			issues: [],
+			detectedIssues: [],
 			singleIssue: typographyIssue,
 		});
 		render(<IssuesWrapper>child</IssuesWrapper>);

--- a/src/components/organisms/IssuesWrapper/index.tsx
+++ b/src/components/organisms/IssuesWrapper/index.tsx
@@ -7,7 +7,7 @@ import ISSUE_TYPE_LABELS from "@/lib/issueTypeLabels";
 import { postMessageToBackend } from "@/lib/figmaUtils";
 import getIssueRecommendations from "@/lib/issueRecommendations";
 import ISSUES_DATA_SCHEMA from "@/lib/issuesData";
-import { IssueType, IssueX } from "@/lib/types";
+import { IssueType, DetectedIssue } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
 import { cn, getContrastIssueDescription, getRouteForIssueType, isActiveIssue } from "@/lib/utils";
 import { ChevronLeft, ChevronRight } from "lucide-react";
@@ -39,13 +39,13 @@ export default function IssuesWrapper({ children }: { children: React.ReactNode 
 	const [hasBackground, setHasBackground] = useState("");
 	const [hasForeground, setHasForeground] = useState("");
 	const {
-		currentIndex,
-		issues,
+		currentIssueIndex,
+		detectedIssues,
 		singleIssue,
 		selectedType,
 		targetLevel,
 		navigateTo,
-		setCurrentIndex,
+		setCurrentIssueIndex,
 		setSelectedType,
 		setSingleIssue,
 		navigateToIssue,
@@ -57,7 +57,9 @@ export default function IssuesWrapper({ children }: { children: React.ReactNode 
 			const { type, data } = event.data.pluginMessage || {};
 
 			if (type === MESSAGE_TYPES.DETECTED_ISSUE) {
-				const matchingIssues = data.filter((issue: IssueX) => issue.type === selectedType);
+				const matchingIssues = data.filter(
+					(issue: DetectedIssue) => issue.type === selectedType,
+				);
 
 				if (matchingIssues.length === 0) {
 					setSingleIssue(null);
@@ -111,24 +113,24 @@ export default function IssuesWrapper({ children }: { children: React.ReactNode 
 	};
 
 	const handleNavigation = (direction: "prev" | "next") => {
-		if (direction === "prev" && currentIndex > 0) {
-			navigateToIssue(currentIndex - 1);
+		if (direction === "prev" && currentIssueIndex > 0) {
+			navigateToIssue(currentIssueIndex - 1);
 		}
-		if (direction === "next" && currentIndex < issueGroupList.length - 1) {
-			navigateToIssue(currentIndex + 1);
+		if (direction === "next" && currentIssueIndex < issueGroupList.length - 1) {
+			navigateToIssue(currentIssueIndex + 1);
 		}
 	};
 
 	const handleSwitchType = (nextType: IssueType) => {
 		if (nextType === selectedType) return;
 		setSelectedType(nextType);
-		setCurrentIndex(0);
+		setCurrentIssueIndex(0);
 		navigateTo(getRouteForIssueType(nextType));
 		navigateToIssue(0);
 	};
 
 	const issueGroupList = getIssueGroupList();
-	const currentIssue = issueGroupList[currentIndex];
+	const currentIssue = issueGroupList[currentIssueIndex];
 	// The issue actually being rendered below (see renderWrapper's call site) -
 	// singleIssue in quick-check mode, currentIssue when paging a scanned
 	// list. description/suggestions need to derive from whichever one that
@@ -142,7 +144,7 @@ export default function IssuesWrapper({ children }: { children: React.ReactNode 
 	// whenever the page has any text at all, even with zero currently-failing
 	// contrast issues.
 	const availableTypes = ISSUES_DATA_SCHEMA.filter((schemaIssue) =>
-		issues.some(
+		detectedIssues.some(
 			(issue) => issue.type === schemaIssue.type && isActiveIssue(issue, targetLevel),
 		),
 	);
@@ -276,20 +278,20 @@ export default function IssuesWrapper({ children }: { children: React.ReactNode 
 							variant="ghost"
 							size="icon"
 							onClick={() => handleNavigation("prev")}
-							disabled={currentIndex === 0}
+							disabled={currentIssueIndex === 0}
 							className="p-2.5"
 						>
 							<ChevronLeft strokeWidth={1.5} aria-hidden="true" className="size-6!" />
 						</Button>
 						<span className="text-sm text-slate-200">
-							Issue {currentIndex + 1} of {issueGroupList.length}
+							Issue {currentIssueIndex + 1} of {issueGroupList.length}
 						</span>
 						<Button
 							title="Goto next issue"
 							variant="ghost"
 							size="icon"
 							onClick={() => handleNavigation("next")}
-							disabled={currentIndex === issueGroupList.length - 1}
+							disabled={currentIssueIndex === issueGroupList.length - 1}
 							className="p-2.5"
 						>
 							<ChevronRight

--- a/src/components/organisms/TouchTargetNavigator/index.test.tsx
+++ b/src/components/organisms/TouchTargetNavigator/index.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { IssueX } from "@/lib/types";
+import { DetectedIssue } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
 
 vi.mock("@/lib/figmaUtils", () => ({ postMessageToBackend: vi.fn() }));
@@ -12,7 +12,7 @@ vi.mock("@/components/organisms/IssuesWrapper", () => ({
 
 import TouchTargetNavigator from "./index";
 
-const touchTargetSizeIssue: IssueX = {
+const touchTargetSizeIssue: DetectedIssue = {
 	type: "TOUCH_TARGET_SIZE",
 	description: "Touch target size is too small.",
 	severity: "minor",
@@ -26,15 +26,15 @@ const touchTargetSizeIssue: IssueX = {
 	},
 };
 
-const touchTargetSpacingIssue: IssueX = {
+const touchTargetSpacingIssue: DetectedIssue = {
 	...touchTargetSizeIssue,
 	type: "TOUCH_TARGET_SPACING",
 };
 
 const defaultState = {
-	issues: [] as IssueX[],
+	detectedIssues: [] as DetectedIssue[],
 	singleIssue: null,
-	currentIndex: 0,
+	currentIssueIndex: 0,
 	selectedType: "" as const,
 };
 
@@ -53,7 +53,7 @@ describe("TouchTargetNavigator", () => {
 	it("renders the element name, current/required size, and severity", () => {
 		useIssuesStore.setState({
 			selectedType: "TOUCH_TARGET_SIZE",
-			issues: [touchTargetSizeIssue],
+			detectedIssues: [touchTargetSizeIssue],
 		});
 		render(<TouchTargetNavigator />);
 
@@ -68,7 +68,7 @@ describe("TouchTargetNavigator", () => {
 		const user = userEvent.setup();
 		useIssuesStore.setState({
 			selectedType: "TOUCH_TARGET_SIZE",
-			issues: [
+			detectedIssues: [
 				{
 					...touchTargetSizeIssue,
 					nodeData: {
@@ -99,7 +99,7 @@ describe("TouchTargetNavigator", () => {
 	it("prefers the node's characters over its name when both are present", () => {
 		useIssuesStore.setState({
 			selectedType: "TOUCH_TARGET_SIZE",
-			issues: [
+			detectedIssues: [
 				{
 					...touchTargetSizeIssue,
 					nodeData: {
@@ -118,7 +118,7 @@ describe("TouchTargetNavigator", () => {
 	it("shows the element-spacing row only for TOUCH_TARGET_SPACING", () => {
 		useIssuesStore.setState({
 			selectedType: "TOUCH_TARGET_SPACING",
-			issues: [touchTargetSpacingIssue],
+			detectedIssues: [touchTargetSpacingIssue],
 		});
 		render(<TouchTargetNavigator />);
 
@@ -128,7 +128,7 @@ describe("TouchTargetNavigator", () => {
 	it("does not show the element-spacing row for TOUCH_TARGET_SIZE", () => {
 		useIssuesStore.setState({
 			selectedType: "TOUCH_TARGET_SIZE",
-			issues: [touchTargetSizeIssue],
+			detectedIssues: [touchTargetSizeIssue],
 		});
 		render(<TouchTargetNavigator />);
 

--- a/src/components/organisms/TouchTargetNavigator/index.tsx
+++ b/src/components/organisms/TouchTargetNavigator/index.tsx
@@ -6,10 +6,10 @@ import { cn, getSeverityStyles } from "@/lib/utils";
 import { Check, MoveHorizontal, OctagonAlert, Ruler, Target, X } from "lucide-react";
 
 export default function TouchTargetNavigator() {
-	const { currentIndex, singleIssue, selectedType, getIssueGroupList } = useIssuesStore();
+	const { currentIssueIndex, singleIssue, selectedType, getIssueGroupList } = useIssuesStore();
 
 	const issueGroupList = getIssueGroupList();
-	const currentIssue = issueGroupList[currentIndex] ?? {};
+	const currentIssue = issueGroupList[currentIssueIndex] ?? {};
 
 	const renderIssueDetails = (issue: typeof singleIssue | null) => {
 		if (!issue) {

--- a/src/lib/figmaUtils/collectIssues/index.ts
+++ b/src/lib/figmaUtils/collectIssues/index.ts
@@ -1,6 +1,6 @@
 import { isLocked, isVisible } from "@create-figma-plugin/utilities";
 import { MIN_FONT_SIZE, TOUCH_TARGET_MIN_SIZE } from "@/lib/constants";
-import { DeviceType, IssueX, TargetLevel } from "@/lib/types";
+import { DeviceType, DetectedIssue, TargetLevel } from "@/lib/types";
 import {
 	analyzeTextNodeForContrastIssue,
 	buildTouchTargetSpatialIndex,
@@ -33,8 +33,8 @@ export function isScannable(node: SceneNode): boolean {
 export async function collectTouchTargetIssues(
 	allPageNodes: SceneNode[],
 	targetLevel: TargetLevel,
-): Promise<IssueX[]> {
-	const issues: IssueX[] = [];
+): Promise<DetectedIssue[]> {
+	const issues: DetectedIssue[] = [];
 	const minSize = TOUCH_TARGET_MIN_SIZE[targetLevel];
 
 	// Building the spatial index and resolving touch-target eligibility are
@@ -77,8 +77,8 @@ export async function collectTouchTargetIssues(
  * have no vitest equivalent, so this needs manual verification in Figma dev
  * mode rather than unit tests.
  */
-async function collectTextNodeIssues(allTextNodes: TextNode[]): Promise<IssueX[]> {
-	const issues: IssueX[] = [];
+async function collectTextNodeIssues(allTextNodes: TextNode[]): Promise<DetectedIssue[]> {
+	const issues: DetectedIssue[] = [];
 
 	await Promise.all(
 		allTextNodes.map(async (textNode) => {
@@ -122,7 +122,7 @@ export async function collectIssues(
 	allPageNodes: SceneNode[],
 	deviceType: DeviceType,
 	targetLevel: TargetLevel,
-): Promise<IssueX[]> {
+): Promise<DetectedIssue[]> {
 	const [textNodeIssues, touchTargetIssues] = await Promise.all([
 		collectTextNodeIssues(allTextNodes),
 		deviceType === "touch" ? collectTouchTargetIssues(allPageNodes, targetLevel) : [],
@@ -196,8 +196,8 @@ export async function detectIssuesInSelection(
 	deviceType: DeviceType,
 	targetLevel: TargetLevel,
 	candidateNodesForSpacing: SceneNode[],
-): Promise<IssueX[]> {
-	const issues: IssueX[] = [];
+): Promise<DetectedIssue[]> {
+	const issues: DetectedIssue[] = [];
 	const minSize = TOUCH_TARGET_MIN_SIZE[targetLevel];
 
 	const expandedEntries = expandSelectionWithDescendants(selectedNodes);

--- a/src/lib/figmaUtils/index.ts
+++ b/src/lib/figmaUtils/index.ts
@@ -1,4 +1,4 @@
-import { contrastScore, IssueX } from "@/lib/types";
+import { contrastScore, DetectedIssue } from "@/lib/types";
 import { RGBColor } from "wcag-contrast";
 import {
 	MESSAGE_TYPES,
@@ -92,9 +92,9 @@ export function replaceTopmostVisibleSolidFillColor(fills: Paint[], color: RGB):
  * Creates a typography issue object for the given TextNode.
  *
  * @param {TextNode} node - The Figma TextNode to analyze.
- * @returns {IssueX} An issue object detailing the typography issue.
+ * @returns {DetectedIssue} An issue object detailing the typography issue.
  */
-export const createTypographyIssue = (node: TextNode): IssueX => ({
+export const createTypographyIssue = (node: TextNode): DetectedIssue => ({
 	description: "Text size is too small for readability.",
 	severity: "major",
 	type: "TYPOGRAPHY",
@@ -312,13 +312,13 @@ export function getNearbyNodes(
  * @param {SceneNode} node - The Figma SceneNode to analyze.
  * @param {"Size" | "Spacing"} issueType - The type of issue ("Size" or "Spacing").
  * @param {number} [minSize] - The minimum size in px this node was checked against; defaults to the WCAG 2.5.5 (AAA) value. Only affects the "Size" issue's description/requiredSize text - spacing isn't level-dependent.
- * @returns {IssueX} An issue object detailing the touch target issue.
+ * @returns {DetectedIssue} An issue object detailing the touch target issue.
  */
 export const createTouchTargetIssue = (
 	node: SceneNode,
 	issueType: "Size" | "Spacing",
 	minSize: number = MIN_TOUCH_TARGET_SIZE_AAA,
-): IssueX | null => {
+): DetectedIssue | null => {
 	if (!node || typeof node !== "object" || !node.id || !node.name) {
 		console.error("Invalid node passed to createTouchTargetIssue:", node);
 		return null;
@@ -354,7 +354,7 @@ export const createTouchTargetIssue = (
  * @param {RGBColor} foregroundColor - The text's foreground color in RGB.
  * @param {BackgroundColorResult | null} background - The resolved background colour plus which node contributed it, or null.
  * @param {boolean} isBold - Whether the text is bold, for the large-text contrast threshold.
- * @returns {IssueX} An issue object detailing the contrast issue.
+ * @returns {DetectedIssue} An issue object detailing the contrast issue.
  */
 export const createContrastIssue = (
 	node: TextNode,
@@ -362,7 +362,7 @@ export const createContrastIssue = (
 	foregroundColor: RGBColor,
 	background: BackgroundColorResult | null,
 	isBold: boolean,
-): IssueX => ({
+): DetectedIssue => ({
 	// No static description here - contrast target-level filtering is
 	// instant/client-side (toggling AA/AAA doesn't rescan), so a description
 	// baked in at scan time can't reflect whichever level is later selected.
@@ -388,7 +388,7 @@ export const createContrastIssue = (
 	},
 });
 
-export async function analyzeTextNodeForContrastIssue(node: TextNode, issues: IssueX[]) {
+export async function analyzeTextNodeForContrastIssue(node: TextNode, issues: DetectedIssue[]) {
 	await figma.loadFontAsync(node.fontName as FontName);
 
 	if ("fills" in node) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -66,7 +66,7 @@ export type NodeDataType = {
 	requiredSizePx?: number;
 };
 
-export interface IssueX {
+export interface DetectedIssue {
 	description?: string;
 	type?: IssueType;
 	severity: Severity;
@@ -75,17 +75,17 @@ export interface IssueX {
 }
 
 export interface IssuesStore {
-	issues: IssueX[]; // List of issues
-	currentIndex: number; // Index of the currently selected issue
+	detectedIssues: DetectedIssue[];
+	currentIssueIndex: number;
 	startScan: () => void; // Start the scan
-	setIssues: (newIssues: IssueX[]) => void; // Setter for issues
-	setCurrentIndex: (index: number) => void; // Setter for the current index
+	setDetectedIssues: (newIssues: DetectedIssue[]) => void; // Setter for issues
+	setCurrentIssueIndex: (index: number) => void;
 	navigateToIssue: (index: number) => void; // Navigate to a specific issue
 }
 
 export interface EnhancedIssuesStore extends IssuesStore {
 	/** An instance of a detected issue. */
-	singleIssue: IssueX | null;
+	singleIssue: DetectedIssue | null;
 	scanning: boolean;
 	/** Selected issue type. Empty string (`""`) means no scan has run yet. */
 	selectedType: IssueType | "";
@@ -93,14 +93,14 @@ export interface EnhancedIssuesStore extends IssuesStore {
 	targetLevel: TargetLevel;
 	deviceType: DeviceType;
 	setScanning: (isScanning: boolean) => void;
-	setSingleIssue: (newIssue: IssueX | null) => void;
+	setSingleIssue: (newIssue: DetectedIssue | null) => void;
 	navigateTo: (route: Routes) => void;
 	setSelectedType: (type: IssueType) => void;
 	setTargetLevel: (level: TargetLevel) => void;
 	setDeviceType: (device: DeviceType) => void;
 	hydrateScanSettings: (settings: { deviceType: DeviceType; targetLevel: TargetLevel }) => void;
-	updateIssue: (id: string, updates: Partial<IssueX>) => void;
-	getIssueGroupList: () => IssueX[];
+	updateIssue: (id: string, updates: Partial<DetectedIssue>) => void;
+	getIssueGroupList: () => DetectedIssue[];
 	rescanIssues: () => void;
 }
 

--- a/src/lib/useIssuesStore/index.test.ts
+++ b/src/lib/useIssuesStore/index.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { IssueX } from "../types";
+import { DetectedIssue } from "../types";
 
 const { postMessageToBackend } = vi.hoisted(() => ({
 	postMessageToBackend: vi.fn(),
@@ -10,7 +10,7 @@ vi.mock("../figmaUtils", () => ({ postMessageToBackend }));
 import { MESSAGE_TYPES } from "../constants";
 import useIssuesStore from "./index";
 
-const issues: IssueX[] = [
+const issues: DetectedIssue[] = [
 	{
 		type: "TYPOGRAPHY",
 		severity: "major",
@@ -27,9 +27,9 @@ describe("useIssuesStore.navigateToIssue", () => {
 	beforeEach(() => {
 		postMessageToBackend.mockClear();
 		useIssuesStore.setState({
-			issues,
+			detectedIssues: issues,
 			selectedType: "TYPOGRAPHY",
-			currentIndex: 0,
+			currentIssueIndex: 0,
 		});
 	});
 
@@ -39,25 +39,25 @@ describe("useIssuesStore.navigateToIssue", () => {
 		expect(postMessageToBackend).toHaveBeenCalledWith(MESSAGE_TYPES.NAVIGATE, {
 			id: "node-2",
 		});
-		expect(useIssuesStore.getState().currentIndex).toBe(1);
+		expect(useIssuesStore.getState().currentIssueIndex).toBe(1);
 	});
 
 	it("does nothing when the index is out of range", () => {
 		useIssuesStore.getState().navigateToIssue(5);
 
 		expect(postMessageToBackend).not.toHaveBeenCalled();
-		expect(useIssuesStore.getState().currentIndex).toBe(0);
+		expect(useIssuesStore.getState().currentIssueIndex).toBe(0);
 	});
 
 	it("does nothing when the index is negative", () => {
 		useIssuesStore.getState().navigateToIssue(-1);
 
 		expect(postMessageToBackend).not.toHaveBeenCalled();
-		expect(useIssuesStore.getState().currentIndex).toBe(0);
+		expect(useIssuesStore.getState().currentIssueIndex).toBe(0);
 	});
 });
 
-function fakeContrastIssue(id: string, compliance: string): IssueX {
+function fakeContrastIssue(id: string, compliance: string): DetectedIssue {
 	return {
 		type: "CONTRAST",
 		severity: "critical",
@@ -73,7 +73,7 @@ function fakeContrastIssue(id: string, compliance: string): IssueX {
 describe("useIssuesStore.getIssueGroupList", () => {
 	it("returns only issues matching the selected type", () => {
 		useIssuesStore.setState({
-			issues: [
+			detectedIssues: [
 				{
 					type: "TYPOGRAPHY",
 					severity: "major",
@@ -95,7 +95,7 @@ describe("useIssuesStore.getIssueGroupList", () => {
 
 	it("includes a CONTRAST issue only when its compliance is Fail", () => {
 		useIssuesStore.setState({
-			issues: [fakeContrastIssue("fail", "Fail"), fakeContrastIssue("pass", "AA")],
+			detectedIssues: [fakeContrastIssue("fail", "Fail"), fakeContrastIssue("pass", "AA")],
 			selectedType: "CONTRAST",
 		});
 
@@ -106,7 +106,7 @@ describe("useIssuesStore.getIssueGroupList", () => {
 
 	it("excludes a CONTRAST issue with no contrastScore at all", () => {
 		useIssuesStore.setState({
-			issues: [
+			detectedIssues: [
 				{
 					type: "CONTRAST",
 					severity: "critical",
@@ -121,7 +121,7 @@ describe("useIssuesStore.getIssueGroupList", () => {
 
 	it("returns an empty list when no scan has run yet (selectedType is empty)", () => {
 		useIssuesStore.setState({
-			issues: [
+			detectedIssues: [
 				{
 					type: "TYPOGRAPHY",
 					severity: "major",
@@ -136,7 +136,7 @@ describe("useIssuesStore.getIssueGroupList", () => {
 
 	it("defaults targetLevel to AA, so only Fail-compliance CONTRAST issues are flagged", () => {
 		useIssuesStore.setState({
-			issues: [
+			detectedIssues: [
 				fakeContrastIssue("fail", "Fail"),
 				fakeContrastIssue("aa-pass", "AA"),
 				fakeContrastIssue("aaa-pass", "AAA"),
@@ -155,7 +155,7 @@ describe("useIssuesStore.getIssueGroupList", () => {
 
 	it("flags AA-only compliant CONTRAST issues once the target level is AAA", () => {
 		useIssuesStore.setState({
-			issues: [
+			detectedIssues: [
 				fakeContrastIssue("fail", "Fail"),
 				fakeContrastIssue("aa-pass", "AA"),
 				fakeContrastIssue("aaa-pass", "AAA"),

--- a/src/lib/useIssuesStore/index.ts
+++ b/src/lib/useIssuesStore/index.ts
@@ -1,13 +1,20 @@
 import { create } from "zustand";
 import { MESSAGE_TYPES } from "../constants";
 import { postMessageToBackend } from "../figmaUtils";
-import { DeviceType, EnhancedIssuesStore, IssueType, IssueX, Routes, TargetLevel } from "../types";
+import {
+	DeviceType,
+	EnhancedIssuesStore,
+	IssueType,
+	DetectedIssue,
+	Routes,
+	TargetLevel,
+} from "../types";
 import { isActiveIssue } from "../utils";
 
 const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
-	issues: [],
+	detectedIssues: [],
 	singleIssue: null,
-	currentIndex: 0,
+	currentIssueIndex: 0,
 	currentRoute: "INDEX", // Default route
 	selectedType: "",
 	scanning: false,
@@ -24,8 +31,8 @@ const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
 		navigateTo("ISSUE_OVERVIEW_LIST_VIEW");
 	},
 	setSingleIssue: (newIssue) => set({ singleIssue: newIssue }),
-	setIssues: (newIssues: IssueX[]) => {
-		set({ issues: newIssues });
+	setDetectedIssues: (newIssues: DetectedIssue[]) => {
+		set({ detectedIssues: newIssues });
 	},
 	setSelectedType: (type: IssueType) => set({ selectedType: type }),
 	setTargetLevel: (level: TargetLevel) => {
@@ -47,23 +54,23 @@ const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
 	hydrateScanSettings: (settings: { deviceType: DeviceType; targetLevel: TargetLevel }) =>
 		set(settings),
 	getIssueGroupList: () => {
-		const { issues, selectedType, targetLevel } = get();
+		const { detectedIssues, selectedType, targetLevel } = get();
 
-		const response = issues.filter(
+		const response = detectedIssues.filter(
 			(issue) => issue.type === selectedType && isActiveIssue(issue, targetLevel),
 		);
 
 		return response;
 	},
-	updateIssue: (id: string, updates: Partial<IssueX>) => {
+	updateIssue: (id: string, updates: Partial<DetectedIssue>) => {
 		set((state) => ({
-			issues: state.issues.map((issue) =>
+			detectedIssues: state.detectedIssues.map((issue) =>
 				issue.nodeData.id === id ? { ...issue, ...updates } : issue,
 			),
 		}));
 	},
-	setCurrentIndex: (index: number) => set({ currentIndex: index }),
-	navigateToIssue: (index: number) => {
+	setCurrentIssueIndex: (index) => set({ currentIssueIndex: index }),
+	navigateToIssue: (index) => {
 		const { getIssueGroupList } = get();
 		const issueGroupList = getIssueGroupList();
 
@@ -71,16 +78,16 @@ const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
 			postMessageToBackend(MESSAGE_TYPES.NAVIGATE, {
 				id: issueGroupList[index].nodeData.id,
 			});
-			set({ currentIndex: index });
+			set({ currentIssueIndex: index });
 		}
 	},
 	navigateTo: (route: Routes) => {
 		set({ currentRoute: route });
 	},
 	rescanIssues: () => {
-		const { startScan, setIssues } = get();
-		setIssues([]); // Clear old issues
-		startScan(); // Start a fresh scan
+		const { startScan, setDetectedIssues } = get();
+		setDetectedIssues([]);
+		startScan();
 	},
 }));
 

--- a/src/lib/utils/index.test.ts
+++ b/src/lib/utils/index.test.ts
@@ -14,7 +14,7 @@ import {
 	isBoldFont,
 	setScanSettings,
 } from "./index";
-import { IssueX } from "@/lib/types";
+import { DetectedIssue } from "@/lib/types";
 
 const WHITE: RGBColor = [255, 255, 255];
 const BLACK: RGBColor = [0, 0, 0];
@@ -374,7 +374,7 @@ describe("getContrastIssueDescription", () => {
 	});
 });
 
-function fakeContrastIssue(compliance: string): IssueX {
+function fakeContrastIssue(compliance: string): DetectedIssue {
 	return {
 		type: "CONTRAST",
 		severity: "critical",
@@ -389,7 +389,7 @@ function fakeContrastIssue(compliance: string): IssueX {
 
 describe("isActiveIssue", () => {
 	it("is always active for non-contrast issue types, regardless of target level", () => {
-		const typographyIssue: IssueX = {
+		const typographyIssue: DetectedIssue = {
 			type: "TYPOGRAPHY",
 			severity: "major",
 			nodeData: { id: "t1", name: "Label", nodeType: "TEXT" },

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,7 +1,14 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { rgb, RGBColor, score } from "wcag-contrast";
-import { copyToClipboardProps, DeviceType, IssueType, IssueX, Routes, TargetLevel } from "../types";
+import {
+	copyToClipboardProps,
+	DeviceType,
+	IssueType,
+	DetectedIssue,
+	Routes,
+	TargetLevel,
+} from "../types";
 
 export function cn(...inputs: ClassValue[]) {
 	// eslint-disable-next-line tailwindcss/no-custom-classname -- false positive: the plugin treats the `inputs` variable reference as if it were a classname string literal.
@@ -74,7 +81,7 @@ export function getContrastIssueDescription(
  * issue type's pass/fail state is fixed at scan time, so it's always active
  * once present.
  */
-export function isActiveIssue(issue: IssueX, targetLevel: TargetLevel): boolean {
+export function isActiveIssue(issue: DetectedIssue, targetLevel: TargetLevel): boolean {
 	if (issue.type === "CONTRAST") {
 		return contrastFailsTargetLevel(issue.nodeData.contrastScore?.compliance, targetLevel);
 	}


### PR DESCRIPTION
## Summary
This is the rename work from #54, re-targeted at `main`. #54 was correctly merged, but its base was `fix/issue-tab-switcher-hides-inactive-types` (a deliberate stack, since the rename touched lines that only existed after that fix). #53 (the tab-switcher fix) merged into `main` *before* #54 finished merging into it, so the rename commit ended up merged into an already-merged branch and never actually reached `main`. Re-opening against `main` now that #53 is there.

Propagates a naming change started in `src/lib/types.ts` (`IssueX` -> `DetectedIssue`; `IssuesStore`'s `issues`/`currentIndex`/`setIssues`/`setCurrentIndex` -> `detectedIssues`/`currentIssueIndex`/`setDetectedIssues`/`setCurrentIssueIndex`) to every remaining consumer - the type-only change alone left the build broken across 14 files.

No behavior change: identifier rename only.

## Test plan
- [x] Clean merge against current `main` (verified via `git merge-tree`, no conflicts)
- [x] `tsc -b`, `npm run lint`, `npm run test` (308 passing), `npm run build` all clean on this exact branch state