### PR TITLE
feat(scan): stream file-scan results progressively, current page first

### DIFF
--- a/plugin/code.ts
+++ b/plugin/code.ts
@@ -14,7 +14,7 @@ import {
 	tagIssuesWithPage,
 } from "@/lib/figmaUtils/collectIssues";
 import generateAltTextForLayer from "@/lib/helpers/generateAltTextForLayer";
-import { DeviceType, DetectedIssue, TargetLevel } from "@/lib/types";
+import { DeviceType, TargetLevel } from "@/lib/types";
 import {
 	figmaRGBtoHex,
 	getIsFileScanCancelled,
@@ -268,8 +268,14 @@ async function handleScanFile(message: ScanSettings) {
 	setScanSettings({ deviceType, targetLevel });
 	setIsFileScanCancelled(false);
 
-	const pages = figma.root.children;
-	const allIssues: DetectedIssue[] = [];
+	// Scan the page the user is currently looking at first, then the rest of
+	// the file in file order - this is what makes streaming worthwhile, since
+	// the first results to land are for the page the user is actually on.
+	const currentPage = figma.currentPage;
+	const pages = [
+		currentPage,
+		...figma.root.children.filter((page) => page.id !== currentPage.id),
+	];
 
 	for (let i = 0; i < pages.length; i++) {
 		if (getIsFileScanCancelled()) break;
@@ -283,7 +289,14 @@ async function handleScanFile(message: ScanSettings) {
 		const allPageNodes = page.findAll((node) => isScannable(node)) as SceneNode[];
 
 		const pageIssues = await collectIssues(allTextNodes, allPageNodes, deviceType, targetLevel);
-		allIssues.push(...tagIssuesWithPage(pageIssues, page.id, page.name));
+		const taggedPageIssues = tagIssuesWithPage(pageIssues, page.id, page.name);
+
+		// Stream this page's results immediately instead of accumulating them
+		// in memory - each page's own array is naturally already a bounded
+		// chunk, so this is both progressive delivery and chunking at once.
+		if (taggedPageIssues.length > 0) {
+			postMessageToUI(MESSAGE_TYPES.SCAN_FILE_PAGE_ISSUES, taggedPageIssues);
+		}
 
 		postMessageToUI(MESSAGE_TYPES.SCAN_FILE_PROGRESS, {
 			pageIndex: i + 1,
@@ -291,13 +304,15 @@ async function handleScanFile(message: ScanSettings) {
 			pageName: page.name,
 		});
 
-		// Yield to the event loop so the progress message above actually
-		// flushes to the UI, and so a CANCEL_SCAN_FILE message sent while this
-		// page was being scanned gets processed before the next page starts.
+		// Yield to the event loop so the messages above actually flush to the
+		// UI, and so a CANCEL_SCAN_FILE message sent while this page was being
+		// scanned gets processed before the next page starts.
 		await new Promise((resolve) => setTimeout(resolve, 0));
 	}
 
-	postMessageToUI(MESSAGE_TYPES.LOAD_ISSUES, allIssues);
+	// Unconditional, same as the old final LOAD_ISSUES send - tells the UI the
+	// scan is over whether it finished naturally or was cancelled partway.
+	postMessageToUI(MESSAGE_TYPES.SCAN_FILE_COMPLETE, { cancelled: getIsFileScanCancelled() });
 }
 
 // Requests the loop above stop after its current page - a boolean gate

--- a/src/App/index.test.tsx
+++ b/src/App/index.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MESSAGE_TYPES } from "@/lib/constants";
+import { DetectedIssue } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
 
 const { postMessageToBackend } = vi.hoisted(() => ({
@@ -15,6 +16,25 @@ function dispatch(type: string, data: unknown) {
 	window.dispatchEvent(new MessageEvent("message", { data: { pluginMessage: { type, data } } }));
 }
 
+const typographyIssue: DetectedIssue = {
+	type: "TYPOGRAPHY",
+	description: "Text size is too small for readability.",
+	severity: "major",
+	nodeData: { id: "t1", name: "Label", nodeType: "TEXT" },
+};
+
+const contrastFailIssue: DetectedIssue = {
+	type: "CONTRAST",
+	description: "Text contrast is below WCAG AA standard.",
+	severity: "critical",
+	nodeData: {
+		id: "c1",
+		name: "Text",
+		nodeType: "TEXT",
+		contrastScore: { compliance: "Fail", ratio: 2 },
+	},
+};
+
 describe("App", () => {
 	beforeEach(() => {
 		postMessageToBackend.mockClear();
@@ -22,6 +42,11 @@ describe("App", () => {
 			currentRoute: "INDEX",
 			targetLevel: "AA",
 			deviceType: "touch",
+			scanning: false,
+			isFileScan: false,
+			fileScanProgress: null,
+			fileScanCancelled: false,
+			detectedIssues: [],
 		});
 	});
 
@@ -67,6 +92,105 @@ describe("App", () => {
 			pageCount: 5,
 			pageName: "About",
 		});
+	});
+
+	it("loads issues from a LOAD_ISSUES message and stops scanning", () => {
+		useIssuesStore.setState({ scanning: true });
+		render(<App />);
+
+		dispatch(MESSAGE_TYPES.LOAD_ISSUES, [typographyIssue]);
+
+		expect(useIssuesStore.getState().scanning).toBe(false);
+		expect(useIssuesStore.getState().detectedIssues).toEqual([typographyIssue]);
+	});
+
+	it("appends streamed-in page issues via SCAN_FILE_PAGE_ISSUES without replacing existing ones", () => {
+		useIssuesStore.setState({
+			scanning: true,
+			isFileScan: true,
+			fileScanProgress: { pageIndex: 1, pageCount: 2, pageName: "Home" },
+			detectedIssues: [typographyIssue],
+		});
+		render(<App />);
+
+		dispatch(MESSAGE_TYPES.SCAN_FILE_PAGE_ISSUES, [contrastFailIssue]);
+
+		expect(useIssuesStore.getState().detectedIssues).toEqual([
+			typographyIssue,
+			contrastFailIssue,
+		]);
+		expect(useIssuesStore.getState().scanning).toBe(true);
+	});
+
+	it("stops scanning and clears progress via SCAN_FILE_COMPLETE without a cancellation", () => {
+		useIssuesStore.setState({
+			scanning: true,
+			isFileScan: true,
+			fileScanProgress: { pageIndex: 2, pageCount: 2, pageName: "About" },
+			detectedIssues: [typographyIssue],
+		});
+		render(<App />);
+
+		dispatch(MESSAGE_TYPES.SCAN_FILE_COMPLETE, { cancelled: false });
+
+		expect(useIssuesStore.getState().scanning).toBe(false);
+		expect(useIssuesStore.getState().fileScanProgress).toBeNull();
+		expect(useIssuesStore.getState().fileScanCancelled).toBe(false);
+	});
+
+	it("clears fileScanProgress once a cancelled file scan's SCAN_FILE_COMPLETE arrives, leaving fileScanCancelled set", () => {
+		useIssuesStore.setState({
+			scanning: true,
+			isFileScan: true,
+			fileScanCancelled: true,
+			fileScanProgress: { pageIndex: 2, pageCount: 3, pageName: "About" },
+			detectedIssues: [typographyIssue],
+		});
+		render(<App />);
+
+		dispatch(MESSAGE_TYPES.SCAN_FILE_COMPLETE, { cancelled: true });
+
+		expect(useIssuesStore.getState().fileScanProgress).toBeNull();
+		expect(useIssuesStore.getState().fileScanCancelled).toBe(true);
+		expect(useIssuesStore.getState().scanning).toBe(false);
+	});
+
+	it("still processes SCAN_FILE_PAGE_ISSUES and SCAN_FILE_COMPLETE while a different screen (not the results overview) is showing", () => {
+		// Regression test: a file scan can keep running in the background while
+		// the user has drilled into an issue's detail view, which unmounts
+		// IssuesOverviewList. Before these messages were handled at this
+		// always-mounted App level, that unmount silently dropped them -
+		// scanning got stuck true forever once the user came back.
+		useIssuesStore.setState({
+			currentRoute: "ISSUE_LIST_VIEW",
+			scanning: true,
+			isFileScan: true,
+			fileScanProgress: { pageIndex: 11, pageCount: 12, pageName: "Checkout" },
+			detectedIssues: [typographyIssue],
+		});
+		render(<App />);
+
+		dispatch(MESSAGE_TYPES.SCAN_FILE_PAGE_ISSUES, [contrastFailIssue]);
+		dispatch(MESSAGE_TYPES.SCAN_FILE_COMPLETE, { cancelled: false });
+
+		expect(useIssuesStore.getState().detectedIssues).toEqual([
+			typographyIssue,
+			contrastFailIssue,
+		]);
+		expect(useIssuesStore.getState().scanning).toBe(false);
+		expect(useIssuesStore.getState().fileScanProgress).toBeNull();
+	});
+
+	it("logs an error and ignores a malformed message", () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		render(<App />);
+
+		window.dispatchEvent(new MessageEvent("message", { data: null }));
+
+		expect(errorSpy).toHaveBeenCalledWith("Invalid message format:", null);
+		expect(useIssuesStore.getState().detectedIssues).toEqual([]);
+
+		errorSpy.mockRestore();
 	});
 
 	it("ignores an unrelated message type", () => {

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -3,7 +3,7 @@ import IssuesNavigator from "@/components/organisms/IssuesNavigator";
 import IssuesOverviewList from "@/components/organisms/IssuesOverviewList";
 import TouchTargetNavigator from "@/components/organisms/TouchTargetNavigator";
 import { MESSAGE_TYPES } from "@/lib/constants";
-import { DeviceType, FileScanProgress, ROUTES_LIST, TargetLevel } from "@/lib/types";
+import { DetectedIssue, DeviceType, FileScanProgress, ROUTES_LIST, TargetLevel } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
 import { cn } from "@/lib/utils";
 import { useEffect } from "react";
@@ -15,11 +15,17 @@ export default function App() {
 		setFileScanProgress,
 		hydrateFileScanOptionSeen,
 		hydratePageCount,
+		setDetectedIssues,
+		appendDetectedIssues,
+		setScanning,
 	} = useIssuesStore();
 
 	useEffect(() => {
 		const handleMessage = (event: MessageEvent) => {
-			if (!event.data || !event.data.pluginMessage) return;
+			if (!event.data || !event.data.pluginMessage) {
+				console.error("Invalid message format:", event.data);
+				return;
+			}
 
 			const { type, data } = event.data.pluginMessage;
 
@@ -38,6 +44,30 @@ export default function App() {
 			if (type === MESSAGE_TYPES.LOAD_PAGE_COUNT) {
 				hydratePageCount((data as { pageCount: number }).pageCount);
 			}
+
+			// Handled here rather than inside IssuesOverviewList: a scan can
+			// keep running in the background while the user is on a different
+			// screen entirely (e.g. drilled into an issue's detail view mid
+			// file-scan), which unmounts IssuesOverviewList and, with it, any
+			// listener it registered. postMessage doesn't replay missed
+			// messages, so a listener that only exists while that one screen
+			// is mounted can permanently miss SCAN_FILE_COMPLETE and leave
+			// `scanning` stuck true forever. App never unmounts, so this is
+			// the one place these are guaranteed not to be dropped.
+			if (type === MESSAGE_TYPES.LOAD_ISSUES) {
+				setDetectedIssues(data as DetectedIssue[]);
+				setScanning(false);
+				setFileScanProgress(null);
+			}
+
+			if (type === MESSAGE_TYPES.SCAN_FILE_PAGE_ISSUES) {
+				appendDetectedIssues(data as DetectedIssue[]);
+			}
+
+			if (type === MESSAGE_TYPES.SCAN_FILE_COMPLETE) {
+				setScanning(false);
+				setFileScanProgress(null);
+			}
 		};
 
 		window.addEventListener("message", handleMessage);
@@ -45,7 +75,15 @@ export default function App() {
 		return () => {
 			window.removeEventListener("message", handleMessage);
 		};
-	}, [hydrateScanSettings, setFileScanProgress, hydrateFileScanOptionSeen, hydratePageCount]);
+	}, [
+		hydrateScanSettings,
+		setFileScanProgress,
+		hydrateFileScanOptionSeen,
+		hydratePageCount,
+		setDetectedIssues,
+		appendDetectedIssues,
+		setScanning,
+	]);
 
 	const RoutesMap: ROUTES_LIST = {
 		INDEX: <AccessibilityValidator />,

--- a/src/components/organisms/IssuesNavigator/index.tsx
+++ b/src/components/organisms/IssuesNavigator/index.tsx
@@ -336,7 +336,7 @@ export default function IssuesNavigator() {
 								}
 								tooltip={
 									isContrastFail &&
-									"The color contrast between the text and the background on this screen is insufficient to meet the enhanced contrast requirements. In some edge cases, the test may fail when the background element is a “GROUP,” “COMPONENT,” or “INSTANCE. Other times, a background couldn't be detected."
+									"The color contrast between the text and the background on this page is insufficient to meet the enhanced contrast requirements. In some edge cases, the test may fail when the background element is a “GROUP,” “COMPONENT,” or “INSTANCE. Other times, a background couldn't be detected."
 								}
 							/>
 

--- a/src/components/organisms/IssuesOverviewList/index.test.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.test.tsx
@@ -17,10 +17,6 @@ vi.mock("file-saver", () => ({ saveAs }));
 
 import IssuesOverviewList from "./index";
 
-function dispatch(type: string, data: unknown) {
-	window.dispatchEvent(new MessageEvent("message", { data: { pluginMessage: { type, data } } }));
-}
-
 async function goToReportTab(user: ReturnType<typeof userEvent.setup>) {
 	await user.click(screen.getByRole("tab", { name: "Report" }));
 }
@@ -180,79 +176,6 @@ describe("IssuesOverviewList", () => {
 		render(<IssuesOverviewList />);
 
 		expect(screen.queryByText(/Scan cancelled/)).toBeNull();
-	});
-
-	it("clears fileScanProgress once SCAN_FILE_COMPLETE arrives, leaving fileScanCancelled for the banner", () => {
-		useIssuesStore.setState({
-			scanning: true,
-			isFileScan: true,
-			fileScanCancelled: true,
-			fileScanProgress: { pageIndex: 2, pageCount: 3, pageName: "About" },
-			detectedIssues: [typographyIssue],
-		});
-		render(<IssuesOverviewList />);
-
-		dispatch(MESSAGE_TYPES.SCAN_FILE_COMPLETE, { cancelled: true });
-
-		expect(useIssuesStore.getState().fileScanProgress).toBeNull();
-		expect(useIssuesStore.getState().fileScanCancelled).toBe(true);
-		expect(useIssuesStore.getState().scanning).toBe(false);
-	});
-
-	it("appends streamed-in page issues via SCAN_FILE_PAGE_ISSUES without replacing existing ones", () => {
-		useIssuesStore.setState({
-			scanning: true,
-			isFileScan: true,
-			fileScanProgress: { pageIndex: 1, pageCount: 2, pageName: "Home" },
-			detectedIssues: [typographyIssue],
-		});
-		render(<IssuesOverviewList />);
-
-		dispatch(MESSAGE_TYPES.SCAN_FILE_PAGE_ISSUES, [contrastFailIssue]);
-
-		expect(useIssuesStore.getState().detectedIssues).toEqual([
-			typographyIssue,
-			contrastFailIssue,
-		]);
-		expect(useIssuesStore.getState().scanning).toBe(true);
-	});
-
-	it("stops scanning and clears progress via SCAN_FILE_COMPLETE without a cancellation", () => {
-		useIssuesStore.setState({
-			scanning: true,
-			isFileScan: true,
-			fileScanProgress: { pageIndex: 2, pageCount: 2, pageName: "About" },
-			detectedIssues: [typographyIssue],
-		});
-		render(<IssuesOverviewList />);
-
-		dispatch(MESSAGE_TYPES.SCAN_FILE_COMPLETE, { cancelled: false });
-
-		expect(useIssuesStore.getState().scanning).toBe(false);
-		expect(useIssuesStore.getState().fileScanProgress).toBeNull();
-		expect(useIssuesStore.getState().fileScanCancelled).toBe(false);
-	});
-
-	it("loads issues from a LOAD_ISSUES message and stops scanning", async () => {
-		useIssuesStore.setState({ scanning: true });
-		render(<IssuesOverviewList />);
-
-		dispatch(MESSAGE_TYPES.LOAD_ISSUES, [typographyIssue]);
-
-		expect(useIssuesStore.getState().scanning).toBe(false);
-		expect(useIssuesStore.getState().detectedIssues).toEqual([typographyIssue]);
-	});
-
-	it("logs an error and ignores a malformed message", () => {
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-		render(<IssuesOverviewList />);
-
-		window.dispatchEvent(new MessageEvent("message", { data: null }));
-
-		expect(errorSpy).toHaveBeenCalledWith("Invalid message format:", null);
-		expect(useIssuesStore.getState().detectedIssues).toEqual([]);
-
-		errorSpy.mockRestore();
 	});
 
 	it("returns to the index and clears issues when the back button is clicked", async () => {

--- a/src/components/organisms/IssuesOverviewList/index.test.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.test.tsx
@@ -61,6 +61,7 @@ const defaultState = {
 	targetLevel: "AA" as const,
 	deviceType: "touch" as const,
 	fileScanProgress: null,
+	isFileScan: false,
 	fileScanCancelled: false,
 	pageScanCancelled: false,
 };
@@ -106,15 +107,34 @@ describe("IssuesOverviewList", () => {
 		expect(screen.getByText(/Scan cancelled/)).toBeVisible();
 	});
 
-	it("shows file-scan progress and a cancel button instead of the plain loading message during a file scan", () => {
+	it("shows a blocking loading screen (not the results view) before the first page of a file scan finishes", () => {
 		useIssuesStore.setState({
 			scanning: true,
-			fileScanProgress: { pageIndex: 2, pageCount: 5, pageName: "About" },
+			isFileScan: true,
+			fileScanProgress: null,
+			pageCount: 5,
 		});
 		render(<IssuesOverviewList />);
 
-		expect(screen.getByText("Scanning page 2 of 5: About")).toBeVisible();
+		expect(screen.getByText("Scanning page 1 of 5...")).toBeVisible();
 		expect(screen.queryByText("Scanning for issues...")).toBeNull();
+		expect(screen.queryByRole("tablist")).toBeNull();
+		expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
+	});
+
+	it("shows the results view with an in-progress banner once the first page of a file scan lands", () => {
+		useIssuesStore.setState({
+			scanning: true,
+			isFileScan: true,
+			fileScanProgress: { pageIndex: 2, pageCount: 5, pageName: "About" },
+			detectedIssues: [typographyIssue],
+		});
+		render(<IssuesOverviewList />);
+
+		expect(
+			screen.getByText(/Scanning page 2 of 5: About\. Results below update/),
+		).toBeVisible();
+		expect(screen.getByRole("tablist")).toBeVisible();
 		expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
 	});
 
@@ -122,6 +142,7 @@ describe("IssuesOverviewList", () => {
 		const user = userEvent.setup();
 		useIssuesStore.setState({
 			scanning: true,
+			isFileScan: true,
 			fileScanProgress: { pageIndex: 1, pageCount: 3, pageName: "Home" },
 		});
 		render(<IssuesOverviewList />);
@@ -130,6 +151,21 @@ describe("IssuesOverviewList", () => {
 
 		expect(useIssuesStore.getState().fileScanCancelled).toBe(true);
 		expect(postMessageToBackend).toHaveBeenCalledWith(MESSAGE_TYPES.CANCEL_SCAN_FILE);
+	});
+
+	it("shows a 'Finishing up' banner with no cancel button once the scan is cancelled but the last page hasn't landed yet", () => {
+		useIssuesStore.setState({
+			scanning: true,
+			isFileScan: true,
+			fileScanCancelled: true,
+			fileScanProgress: { pageIndex: 3, pageCount: 5, pageName: "Contact" },
+			detectedIssues: [typographyIssue],
+		});
+		render(<IssuesOverviewList />);
+
+		expect(screen.getByText("Finishing up - page 3 of 5...")).toBeVisible();
+		expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+		expect(screen.queryByText(/Scan cancelled/)).toBeNull();
 	});
 
 	it("shows a partial-results banner after a cancelled file scan's results arrive", () => {
@@ -146,19 +182,55 @@ describe("IssuesOverviewList", () => {
 		expect(screen.queryByText(/Scan cancelled/)).toBeNull();
 	});
 
-	it("clears fileScanProgress once LOAD_ISSUES arrives, leaving fileScanCancelled for the banner", () => {
+	it("clears fileScanProgress once SCAN_FILE_COMPLETE arrives, leaving fileScanCancelled for the banner", () => {
 		useIssuesStore.setState({
 			scanning: true,
+			isFileScan: true,
 			fileScanCancelled: true,
 			fileScanProgress: { pageIndex: 2, pageCount: 3, pageName: "About" },
+			detectedIssues: [typographyIssue],
 		});
 		render(<IssuesOverviewList />);
 
-		dispatch(MESSAGE_TYPES.LOAD_ISSUES, [typographyIssue]);
+		dispatch(MESSAGE_TYPES.SCAN_FILE_COMPLETE, { cancelled: true });
 
 		expect(useIssuesStore.getState().fileScanProgress).toBeNull();
 		expect(useIssuesStore.getState().fileScanCancelled).toBe(true);
 		expect(useIssuesStore.getState().scanning).toBe(false);
+	});
+
+	it("appends streamed-in page issues via SCAN_FILE_PAGE_ISSUES without replacing existing ones", () => {
+		useIssuesStore.setState({
+			scanning: true,
+			isFileScan: true,
+			fileScanProgress: { pageIndex: 1, pageCount: 2, pageName: "Home" },
+			detectedIssues: [typographyIssue],
+		});
+		render(<IssuesOverviewList />);
+
+		dispatch(MESSAGE_TYPES.SCAN_FILE_PAGE_ISSUES, [contrastFailIssue]);
+
+		expect(useIssuesStore.getState().detectedIssues).toEqual([
+			typographyIssue,
+			contrastFailIssue,
+		]);
+		expect(useIssuesStore.getState().scanning).toBe(true);
+	});
+
+	it("stops scanning and clears progress via SCAN_FILE_COMPLETE without a cancellation", () => {
+		useIssuesStore.setState({
+			scanning: true,
+			isFileScan: true,
+			fileScanProgress: { pageIndex: 2, pageCount: 2, pageName: "About" },
+			detectedIssues: [typographyIssue],
+		});
+		render(<IssuesOverviewList />);
+
+		dispatch(MESSAGE_TYPES.SCAN_FILE_COMPLETE, { cancelled: false });
+
+		expect(useIssuesStore.getState().scanning).toBe(false);
+		expect(useIssuesStore.getState().fileScanProgress).toBeNull();
+		expect(useIssuesStore.getState().fileScanCancelled).toBe(false);
 	});
 
 	it("loads issues from a LOAD_ISSUES message and stops scanning", async () => {
@@ -246,7 +318,7 @@ describe("IssuesOverviewList", () => {
 		});
 		render(<IssuesOverviewList />);
 
-		expect(screen.getByText("There are 2 issues detected on this screen.")).toBeVisible();
+		expect(screen.getByText("There are 2 issues detected on this page.")).toBeVisible();
 
 		const contrastRow = screen.getByRole("button", { name: "Contrast" });
 		expect(contrastRow).toHaveTextContent("1");
@@ -255,6 +327,17 @@ describe("IssuesOverviewList", () => {
 
 		expect(useIssuesStore.getState().selectedType).toBe("TYPOGRAPHY");
 		expect(useIssuesStore.getState().currentRoute).toBe("ISSUE_LIST_VIEW");
+	});
+
+	it("says 'across this file', not 'on this page', when the issues came from a file scan", () => {
+		useIssuesStore.setState({
+			isFileScan: true,
+			detectedIssues: [typographyIssue, contrastFailIssue],
+		});
+		render(<IssuesOverviewList />);
+
+		expect(screen.getByText("There are 2 issues detected across this file.")).toBeVisible();
+		expect(screen.queryByText(/on this page/)).toBeNull();
 	});
 
 	it("does not show the WCAG target toggle when there are no contrast issues", () => {
@@ -281,12 +364,12 @@ describe("IssuesOverviewList", () => {
 		});
 		render(<IssuesOverviewList />);
 
-		expect(screen.getByText("There are 1 issues detected on this screen.")).toBeVisible();
+		expect(screen.getByText("There are 1 issues detected on this page.")).toBeVisible();
 
 		await user.click(screen.getByRole("radio", { name: "AAA" }));
 
 		expect(useIssuesStore.getState().targetLevel).toBe("AAA");
-		expect(screen.getByText("There are 2 issues detected on this screen.")).toBeVisible();
+		expect(screen.getByText("There are 2 issues detected on this page.")).toBeVisible();
 	});
 
 	it("shows the category breakdown chart on the Report tab only when there are counted issues", async () => {

--- a/src/components/organisms/IssuesOverviewList/index.test.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.test.tsx
@@ -228,6 +228,24 @@ describe("IssuesOverviewList", () => {
 		expect(useIssuesStore.getState().scanning).toBe(true);
 	});
 
+	it("rescans with a file scan, not a plain page scan, when the current results came from a file scan", async () => {
+		const user = userEvent.setup();
+		useIssuesStore.setState({ isFileScan: true, detectedIssues: [typographyIssue] });
+		render(<IssuesOverviewList />);
+
+		await user.click(screen.getByRole("button", { name: "Rescan for issues" }));
+
+		expect(postMessageToBackend).toHaveBeenCalledWith(MESSAGE_TYPES.SCAN_FILE, {
+			deviceType: "touch",
+			targetLevel: "AA",
+		});
+		expect(postMessageToBackend).not.toHaveBeenCalledWith(
+			MESSAGE_TYPES.SCAN,
+			expect.anything(),
+		);
+		expect(useIssuesStore.getState().scanning).toBe(true);
+	});
+
 	it("shows 'No issues found' when there are no issues", () => {
 		render(<IssuesOverviewList />);
 

--- a/src/components/organisms/IssuesOverviewList/index.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.tsx
@@ -29,6 +29,7 @@ export default function IssuesOverviewList() {
 		scanning,
 		detectedIssues,
 		setDetectedIssues,
+		appendDetectedIssues,
 		setScanning,
 		setSelectedType,
 		navigateTo,
@@ -37,11 +38,13 @@ export default function IssuesOverviewList() {
 		setTargetLevel,
 		deviceType,
 		fileScanProgress,
+		isFileScan,
 		fileScanCancelled,
 		cancelFileScan,
 		setFileScanProgress,
 		pageScanCancelled,
 		cancelPageScan,
+		pageCount,
 	} = useIssuesStore();
 
 	const issuesGroupListRecords = detectedIssues.filter((issue) => {
@@ -66,6 +69,15 @@ export default function IssuesOverviewList() {
 				setScanning(false);
 				setFileScanProgress(null);
 			}
+
+			if (type === MESSAGE_TYPES.SCAN_FILE_PAGE_ISSUES) {
+				appendDetectedIssues(data);
+			}
+
+			if (type === MESSAGE_TYPES.SCAN_FILE_COMPLETE) {
+				setScanning(false);
+				setFileScanProgress(null);
+			}
 		};
 
 		window.addEventListener("message", handleMessage);
@@ -73,7 +85,7 @@ export default function IssuesOverviewList() {
 		return () => {
 			window.removeEventListener("message", handleMessage);
 		};
-	}, [setDetectedIssues, setScanning, setFileScanProgress]);
+	}, [setDetectedIssues, appendDetectedIssues, setScanning, setFileScanProgress]);
 
 	const handleIssuesListClick = (type: IssueType) => {
 		setSelectedType(type);
@@ -153,6 +165,15 @@ export default function IssuesOverviewList() {
 		saveAs(jsonBlob, "accessibility-issues-report.json");
 	};
 
+	// True once there's something worth showing - either the scan is fully
+	// done, or it's a file scan whose first page has already streamed in.
+	// fileScanProgress only ever becomes non-null after a page's progress
+	// message arrives, and that page's SCAN_FILE_PAGE_ISSUES is always sent
+	// (and processed, given in-order postMessage delivery) before its
+	// SCAN_FILE_PROGRESS - so this is a reliable "first page already landed"
+	// signal without needing a separate counter.
+	const showResults = !scanning || (isFileScan && fileScanProgress !== null);
+
 	return (
 		<div className="flex size-full flex-col">
 			<div className="grid">
@@ -193,9 +214,29 @@ export default function IssuesOverviewList() {
 				<Separator className="my-2 h-px bg-rose-50/10!" />
 			</div>
 
-			{!scanning ? (
+			{showResults ? (
 				<div className="flex size-full flex-col">
-					{(fileScanCancelled || pageScanCancelled) && (
+					{scanning && isFileScan && fileScanProgress && (
+						<div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-rose-50/10 bg-dark-shade px-3 py-2 text-xs text-grey">
+							<span>
+								{fileScanCancelled
+									? `Finishing up - page ${fileScanProgress.pageIndex} of ${fileScanProgress.pageCount}...`
+									: `Scanning page ${fileScanProgress.pageIndex} of ${fileScanProgress.pageCount}: ${fileScanProgress.pageName}. Results below update as more pages finish.`}
+							</span>
+							{!fileScanCancelled && (
+								<Button
+									title="Cancel scan"
+									variant="ghost"
+									className="shrink-0 border border-rose-50/10"
+									onClick={cancelFileScan}
+								>
+									Cancel
+								</Button>
+							)}
+						</div>
+					)}
+
+					{!scanning && (fileScanCancelled || pageScanCancelled) && (
 						<p className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-500">
 							Scan cancelled - showing results collected before you cancelled.
 						</p>
@@ -236,8 +277,8 @@ export default function IssuesOverviewList() {
 
 							{issuesGroupListRecords.length > 0 && (
 								<p className="mb-4 font-open-sans text-sm">
-									There are {issuesGroupListRecords.length} issues detected on
-									this screen.
+									There are {issuesGroupListRecords.length} issues detected{" "}
+									{isFileScan ? "across this file" : "on this page"}.
 								</p>
 							)}
 
@@ -339,10 +380,8 @@ export default function IssuesOverviewList() {
 						</TabsContent>
 					</Tabs>
 				</div>
-			) : fileScanProgress ? (
-				<LoadingScreen
-					message={`Scanning page ${fileScanProgress.pageIndex} of ${fileScanProgress.pageCount}: ${fileScanProgress.pageName}`}
-				>
+			) : scanning && isFileScan ? (
+				<LoadingScreen message={`Scanning page 1 of ${pageCount}...`}>
 					<Button
 						title="Cancel scan"
 						variant="ghost"

--- a/src/components/organisms/IssuesOverviewList/index.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.tsx
@@ -8,7 +8,7 @@ import TargetLevelToggle from "@/components/organisms/TargetLevelToggle";
 import { Button } from "@/components/ui/button";
 import Separator from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { ISSUES_TYPES, MESSAGE_TYPES } from "@/lib/constants";
+import { ISSUES_TYPES } from "@/lib/constants";
 import ISSUE_TYPE_LABELS from "@/lib/issueTypeLabels";
 import ISSUES_DATA_SCHEMA from "@/lib/issuesData";
 import { IssueType, DetectedIssue } from "@/lib/types";
@@ -22,15 +22,12 @@ import {
 } from "@/lib/utils";
 import { saveAs } from "file-saver";
 import { RefreshCcw } from "lucide-react";
-import { useEffect } from "react";
 
 export default function IssuesOverviewList() {
 	const {
 		scanning,
 		detectedIssues,
 		setDetectedIssues,
-		appendDetectedIssues,
-		setScanning,
 		setSelectedType,
 		navigateTo,
 		rescanIssues,
@@ -41,7 +38,6 @@ export default function IssuesOverviewList() {
 		isFileScan,
 		fileScanCancelled,
 		cancelFileScan,
-		setFileScanProgress,
 		pageScanCancelled,
 		cancelPageScan,
 		pageCount,
@@ -53,39 +49,6 @@ export default function IssuesOverviewList() {
 	});
 
 	const hasContrastIssues = detectedIssues.some((issue) => issue.type === "CONTRAST");
-
-	// Listen for messages from the backend
-	useEffect(() => {
-		const handleMessage = (event: MessageEvent) => {
-			if (!event.data || !event.data.pluginMessage) {
-				console.error("Invalid message format:", event.data);
-				return;
-			}
-
-			const { type, data } = event.data.pluginMessage;
-
-			if (type === MESSAGE_TYPES.LOAD_ISSUES) {
-				setDetectedIssues(data);
-				setScanning(false);
-				setFileScanProgress(null);
-			}
-
-			if (type === MESSAGE_TYPES.SCAN_FILE_PAGE_ISSUES) {
-				appendDetectedIssues(data);
-			}
-
-			if (type === MESSAGE_TYPES.SCAN_FILE_COMPLETE) {
-				setScanning(false);
-				setFileScanProgress(null);
-			}
-		};
-
-		window.addEventListener("message", handleMessage);
-
-		return () => {
-			window.removeEventListener("message", handleMessage);
-		};
-	}, [setDetectedIssues, appendDetectedIssues, setScanning, setFileScanProgress]);
 
 	const handleIssuesListClick = (type: IssueType) => {
 		setSelectedType(type);

--- a/src/components/organisms/ai-assistants/AltTextGenerator/index.test.tsx
+++ b/src/components/organisms/ai-assistants/AltTextGenerator/index.test.tsx
@@ -78,6 +78,24 @@ describe("AltTextGenerator", () => {
 		expect(setIsExpanded).toHaveBeenCalledWith(false);
 	});
 
+	// Regression guard: event.data can be null (e.g. some non-plugin message
+	// event landing on this window), and the handler used to do
+	// `event.data.pluginMessage` with no null check, throwing synchronously
+	// inside an async handler - which surfaces as an unhandled promise
+	// rejection, not a synchronous throw this test can catch with
+	// expect(...).toThrow(). The real signal here is `vitest run` itself:
+	// jsdom doesn't reliably re-dispatch `unhandledrejection` on `window` in
+	// this setup, but Vitest's own unhandled-rejection detection still fails
+	// the whole test run if this regresses, even though the test below
+	// "passes" - confirmed by deliberately reintroducing the bug locally.
+	it("ignores a message with no event.data at all", () => {
+		render(<AltTextGenerator isExpanded setIsExpanded={vi.fn()} />);
+
+		window.dispatchEvent(new MessageEvent("message", { data: null }));
+
+		expect(postMessageToBackend).not.toHaveBeenCalled();
+	});
+
 	it("does not expose the collapse button while collapsed", () => {
 		render(<AltTextGenerator isExpanded={false} setIsExpanded={vi.fn()} />);
 

--- a/src/components/organisms/ai-assistants/AltTextGenerator/index.tsx
+++ b/src/components/organisms/ai-assistants/AltTextGenerator/index.tsx
@@ -21,7 +21,7 @@ export default function AltTextGenerator({ isExpanded, setIsExpanded }: AltTextG
 
 	useEffect(() => {
 		const handleMessage = async (event: MessageEvent) => {
-			const { type, data } = event.data.pluginMessage || {};
+			const { type, data } = event.data?.pluginMessage || {};
 
 			if (type === MESSAGE_TYPES.GENERATE_ALT_TEXT) {
 				try {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,6 +8,8 @@ export const MESSAGE_TYPES = {
 	CANCEL_SCAN: "cancel-scan",
 	SCAN_FILE: "scan-file",
 	SCAN_FILE_PROGRESS: "scan-file-progress",
+	SCAN_FILE_PAGE_ISSUES: "scan-file-page-issues",
+	SCAN_FILE_COMPLETE: "scan-file-complete",
 	CANCEL_SCAN_FILE: "cancel-scan-file",
 	UPDATE_FONT_SIZE: "update-font-size",
 	UPDATE_FILL_COLOR: "update-fill-color",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -107,6 +107,8 @@ export interface EnhancedIssuesStore extends IssuesStore {
 	deviceType: DeviceType;
 	/** Non-null only while a full-file (all-pages) scan is in progress - see startFileScan. */
 	fileScanProgress: FileScanProgress | null;
+	/** True only while a *file* scan (not a plain single-page scan) is in flight - disambiguates the "scanning: true, fileScanProgress: null" window (before the first page's progress arrives) from a single-page scan, which looks identical otherwise. */
+	isFileScan: boolean;
 	/** True once the user cancels an in-progress file scan, until the next scan starts. */
 	fileScanCancelled: boolean;
 	/** True once the user cancels an in-progress single-page scan, until the next scan starts. */
@@ -139,6 +141,8 @@ export interface EnhancedIssuesStore extends IssuesStore {
 	hydrateFileScanOptionSeen: (seen: boolean) => void;
 	/** Applies a just-broadcast page count - no repost, mirrors hydrateFileScanOptionSeen. */
 	hydratePageCount: (count: number) => void;
+	/** Appends to detectedIssues rather than replacing it - for streamed-in SCAN_FILE_PAGE_ISSUES chunks. */
+	appendDetectedIssues: (newIssues: DetectedIssue[]) => void;
 }
 
 export type copyToClipboardProps = {

--- a/src/lib/useIssuesStore/index.test.ts
+++ b/src/lib/useIssuesStore/index.test.ts
@@ -274,6 +274,14 @@ describe("useIssuesStore.startScan", () => {
 
 		expect(useIssuesStore.getState().pageScanCancelled).toBe(false);
 	});
+
+	it("clears isFileScan left over from a previous file scan", () => {
+		useIssuesStore.setState({ isFileScan: true });
+
+		useIssuesStore.getState().startScan();
+
+		expect(useIssuesStore.getState().isFileScan).toBe(false);
+	});
 });
 
 describe("useIssuesStore.cancelPageScan", () => {
@@ -356,6 +364,40 @@ describe("useIssuesStore.startFileScan", () => {
 
 		expect(useIssuesStore.getState().fileScanProgress).toBeNull();
 		expect(useIssuesStore.getState().fileScanCancelled).toBe(false);
+	});
+
+	it("sets isFileScan to true", () => {
+		useIssuesStore.setState({ isFileScan: false });
+
+		useIssuesStore.getState().startFileScan();
+
+		expect(useIssuesStore.getState().isFileScan).toBe(true);
+	});
+
+	it("clears any leftover detectedIssues from a previous scan before starting", () => {
+		useIssuesStore.setState({ detectedIssues: issues });
+
+		useIssuesStore.getState().startFileScan();
+
+		expect(useIssuesStore.getState().detectedIssues).toEqual([]);
+	});
+});
+
+describe("useIssuesStore.appendDetectedIssues", () => {
+	it("appends to existing detectedIssues without replacing them", () => {
+		useIssuesStore.setState({ detectedIssues: [issues[0]] });
+
+		useIssuesStore.getState().appendDetectedIssues([issues[1]]);
+
+		expect(useIssuesStore.getState().detectedIssues).toEqual([issues[0], issues[1]]);
+	});
+
+	it("appends onto an empty array", () => {
+		useIssuesStore.setState({ detectedIssues: [] });
+
+		useIssuesStore.getState().appendDetectedIssues(issues);
+
+		expect(useIssuesStore.getState().detectedIssues).toEqual(issues);
 	});
 });
 

--- a/src/lib/useIssuesStore/index.test.ts
+++ b/src/lib/useIssuesStore/index.test.ts
@@ -383,6 +383,53 @@ describe("useIssuesStore.startFileScan", () => {
 	});
 });
 
+describe("useIssuesStore.rescanIssues", () => {
+	it("repeats a plain page scan (posts SCAN) when the current results came from a page scan", () => {
+		postMessageToBackend.mockClear();
+		useIssuesStore.setState({
+			isFileScan: false,
+			detectedIssues: issues,
+			deviceType: "pointer",
+			targetLevel: "AAA",
+		});
+
+		useIssuesStore.getState().rescanIssues();
+
+		expect(postMessageToBackend).toHaveBeenCalledWith(MESSAGE_TYPES.SCAN, {
+			deviceType: "pointer",
+			targetLevel: "AAA",
+		});
+		expect(postMessageToBackend).not.toHaveBeenCalledWith(
+			MESSAGE_TYPES.SCAN_FILE,
+			expect.anything(),
+		);
+		expect(useIssuesStore.getState().detectedIssues).toEqual([]);
+	});
+
+	it("repeats a file scan (posts SCAN_FILE) when the current results came from a file scan", () => {
+		postMessageToBackend.mockClear();
+		useIssuesStore.setState({
+			isFileScan: true,
+			detectedIssues: issues,
+			deviceType: "touch",
+			targetLevel: "AA",
+		});
+
+		useIssuesStore.getState().rescanIssues();
+
+		expect(postMessageToBackend).toHaveBeenCalledWith(MESSAGE_TYPES.SCAN_FILE, {
+			deviceType: "touch",
+			targetLevel: "AA",
+		});
+		expect(postMessageToBackend).not.toHaveBeenCalledWith(
+			MESSAGE_TYPES.SCAN,
+			expect.anything(),
+		);
+		expect(useIssuesStore.getState().isFileScan).toBe(true);
+		expect(useIssuesStore.getState().detectedIssues).toEqual([]);
+	});
+});
+
 describe("useIssuesStore.appendDetectedIssues", () => {
 	it("appends to existing detectedIssues without replacing them", () => {
 		useIssuesStore.setState({ detectedIssues: [issues[0]] });

--- a/src/lib/useIssuesStore/index.ts
+++ b/src/lib/useIssuesStore/index.ts
@@ -22,6 +22,7 @@ const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
 	targetLevel: "AA",
 	deviceType: "touch",
 	fileScanProgress: null,
+	isFileScan: false,
 	fileScanCancelled: false,
 	pageScanCancelled: false,
 	hasSeenFileScanOption: false,
@@ -36,14 +37,24 @@ const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
 		// Clears cancelled flags left over from a previous scan - e.g. "Rescan"
 		// after cancelling a file scan runs a plain single-page scan, which
 		// shouldn't inherit the earlier cancellation's "partial results" banner.
-		set({ fileScanCancelled: false, pageScanCancelled: false });
+		set({ fileScanCancelled: false, pageScanCancelled: false, isFileScan: false });
 		postMessageToBackend(MESSAGE_TYPES.SCAN, { deviceType, targetLevel });
 		navigateTo("ISSUE_OVERVIEW_LIST_VIEW");
 	},
 	startFileScan: () => {
-		const { setScanning, navigateTo, deviceType, targetLevel } = get();
+		const { setScanning, setDetectedIssues, navigateTo, deviceType, targetLevel } = get();
+		// Clears any leftover issues from a previous scan - unlike rescanIssues
+		// (which does this before starting a plain scan), a file scan streams
+		// issues in progressively, so a stale array here would sit underneath
+		// the first streamed-in chunk instead of being replaced by it.
+		setDetectedIssues([]);
 		setScanning(true);
-		set({ fileScanProgress: null, fileScanCancelled: false, pageScanCancelled: false });
+		set({
+			fileScanProgress: null,
+			fileScanCancelled: false,
+			pageScanCancelled: false,
+			isFileScan: true,
+		});
 		postMessageToBackend(MESSAGE_TYPES.SCAN_FILE, { deviceType, targetLevel });
 		navigateTo("ISSUE_OVERVIEW_LIST_VIEW");
 	},
@@ -68,6 +79,9 @@ const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
 	setSelectionIssues: (issues) => set({ selectionIssues: issues }),
 	setDetectedIssues: (newIssues: DetectedIssue[]) => {
 		set({ detectedIssues: newIssues });
+	},
+	appendDetectedIssues: (newIssues: DetectedIssue[]) => {
+		set((state) => ({ detectedIssues: [...state.detectedIssues, ...newIssues] }));
 	},
 	setSelectedType: (type: IssueType) => set({ selectedType: type }),
 	setTargetLevel: (level: TargetLevel) => {

--- a/src/lib/useIssuesStore/index.ts
+++ b/src/lib/useIssuesStore/index.ts
@@ -34,9 +34,9 @@ const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
 	startScan: () => {
 		const { setScanning, navigateTo, deviceType, targetLevel } = get();
 		setScanning(true);
-		// Clears cancelled flags left over from a previous scan - e.g. "Rescan"
-		// after cancelling a file scan runs a plain single-page scan, which
-		// shouldn't inherit the earlier cancellation's "partial results" banner.
+		// Clears cancelled flags left over from a previous scan, so a fresh
+		// scan started from the landing screen doesn't inherit a stale
+		// "partial results" banner from an earlier, different-type scan.
 		set({ fileScanCancelled: false, pageScanCancelled: false, isFileScan: false });
 		postMessageToBackend(MESSAGE_TYPES.SCAN, { deviceType, targetLevel });
 		navigateTo("ISSUE_OVERVIEW_LIST_VIEW");
@@ -135,7 +135,14 @@ const useIssuesStore = create<EnhancedIssuesStore>((set, get) => ({
 		set({ currentRoute: route });
 	},
 	rescanIssues: () => {
-		const { startScan, setDetectedIssues } = get();
+		const { isFileScan, startScan, startFileScan, setDetectedIssues } = get();
+		// Repeats whichever scan type produced the results currently shown -
+		// startFileScan already clears detectedIssues itself (see its own
+		// comment above), so only the plain-scan path needs to do it here.
+		if (isFileScan) {
+			startFileScan();
+			return;
+		}
 		setDetectedIssues([]);
 		startScan();
 	},


### PR DESCRIPTION
## Summary

Picks up two roadmap items deferred from the full-file-scan feature (reordering pages current-first, chunking large result sets) and combines them into progressive delivery rather than a purely batched fix, per the decision to prioritize a genuine competitive differentiator over the smallest safe change.

- `handleScanFile` now scans the page the user currently has open first, then the rest of the file in file order.
- Each page's issues stream to the UI (`SCAN_FILE_PAGE_ISSUES`) as soon as that page finishes, instead of accumulating in memory and sending one `LOAD_ISSUES` at the very end. `SCAN_FILE_COMPLETE` replaces that final send for file scans, unconditionally (cancelled or not).
- The results screen now renders as soon as the first page's issues land — fully interactive (filterable, exportable) — while later pages keep scanning in the background, shown via a new in-progress banner ("Results below update as more pages finish" / "Finishing up..." once cancelled).

### Bugs fixed along the way
- `startFileScan` didn't clear stale `detectedIssues` from a previous scan before starting — harmless under the old fully-batched model, but would have left old issues sitting under the first streamed-in chunk.
- The cancel button during the pre-first-page window (`scanning: true`, no progress yet) was wired to `CANCEL_SCAN` instead of `CANCEL_SCAN_FILE` — a new `isFileScan` store flag disambiguates this window from a plain single-page scan.
- "There are N issues detected on this screen" read wrong once issues span multiple pages — now "across this file" for file scans, "on this page" for single-page scans. Applied the same screen→page wording fix to the contrast-fail tooltip in `IssuesNavigator`.
- **Reported after initial manual testing**: drilling into an issue's detail view mid file-scan (unmounting `IssuesOverviewList`) permanently dropped any `SCAN_FILE_PAGE_ISSUES`/`SCAN_FILE_COMPLETE` messages that arrived while away — `scanning` got stuck `true` forever, Cancel appeared to do nothing. Fixed by moving that message handling to `App`'s always-mounted top-level listener (same place `SCAN_FILE_PROGRESS` already lived), so it's never dropped regardless of which screen is showing. Also fixed a related latent bug this surfaced: `AltTextGenerator`'s own message listener crashed on a `null` `event.data` with no guard.
- **Reported after initial manual testing**: "Rescan" always ran a plain single-page scan (`startScan`) even when the results being rescanned came from a file scan, silently losing coverage of every other page. `rescanIssues` now branches on `isFileScan` and repeats whichever scan type produced the current results.

## Test plan
- [x] `npx tsc -b`
- [x] `npm run lint`
- [x] `npm run test` (400/400 passing)
- [x] `npm run build`
- [x] Mutation-tested the append-not-replace semantics, the `showResults` render gate, the App-level message handling fix, and the rescan-repeats-scan-type fix to confirm the tests actually catch regressions
- [x] Manual verification in Figma dev mode on a real multi-page file: current-page-first ordering, progressive rendering while later pages still scan, cancel mid-scan ("Finishing up" → cancelled banner), AA/AAA toggle mid-scan, single-page scan path unchanged, zero-issue page handling, cross-page issue navigation, drilling into an issue mid-scan and back (no longer gets stuck), and Rescan after a file scan (now repeats the file scan) — all confirmed working
