### PR TITLE
fix(a11y): disable Back button on the results screen while a scan is running

### DIFF
--- a/src/components/organisms/IssuesOverviewList/index.test.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.test.tsx
@@ -194,6 +194,31 @@ describe("IssuesOverviewList", () => {
 		expect(useIssuesStore.getState().detectedIssues).toEqual([]);
 	});
 
+	it("disables the back button while a scan is in progress", async () => {
+		const user = userEvent.setup();
+		useIssuesStore.setState({
+			scanning: true,
+			currentRoute: "ISSUE_OVERVIEW_LIST_VIEW",
+			detectedIssues: [typographyIssue],
+		});
+		render(<IssuesOverviewList />);
+
+		const backButton = screen.getByRole("button", { name: "Back" });
+		expect(backButton).toBeDisabled();
+
+		await user.click(backButton);
+
+		expect(useIssuesStore.getState().currentRoute).toBe("ISSUE_OVERVIEW_LIST_VIEW");
+		expect(useIssuesStore.getState().detectedIssues).toEqual([typographyIssue]);
+	});
+
+	it("re-enables the back button once scanning finishes", () => {
+		useIssuesStore.setState({ scanning: false });
+		render(<IssuesOverviewList />);
+
+		expect(screen.getByRole("button", { name: "Back" })).toBeEnabled();
+	});
+
 	it("rescans by clearing issues and starting a new scan", async () => {
 		const user = userEvent.setup();
 		useIssuesStore.setState({ detectedIssues: [typographyIssue] });

--- a/src/components/organisms/IssuesOverviewList/index.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.tsx
@@ -161,6 +161,7 @@ export default function IssuesOverviewList() {
 						navigateTo("INDEX");
 						setDetectedIssues([]);
 					}}
+					disabled={scanning}
 				>
 					<div className="inline-flex items-center">
 						{!scanning && (

--- a/src/components/organisms/ScreenHeader/index.test.tsx
+++ b/src/components/organisms/ScreenHeader/index.test.tsx
@@ -29,4 +29,32 @@ describe("ScreenHeader", () => {
 
 		expect(onBack).toHaveBeenCalledTimes(1);
 	});
+
+	it("is enabled by default", () => {
+		render(
+			<ScreenHeader onBack={vi.fn()}>
+				<span>Scan Results</span>
+			</ScreenHeader>,
+		);
+
+		expect(screen.getByRole("button", { name: /back/i })).toBeEnabled();
+	});
+
+	it("disables the back button when disabled is true", async () => {
+		const user = userEvent.setup();
+		const onBack = vi.fn();
+
+		render(
+			<ScreenHeader onBack={onBack} disabled>
+				<span>Scan Results</span>
+			</ScreenHeader>,
+		);
+
+		const backButton = screen.getByRole("button", { name: /back/i });
+		expect(backButton).toBeDisabled();
+
+		await user.click(backButton);
+
+		expect(onBack).not.toHaveBeenCalled();
+	});
 });

--- a/src/components/organisms/ScreenHeader/index.tsx
+++ b/src/components/organisms/ScreenHeader/index.tsx
@@ -5,9 +5,11 @@ import { ReactNode } from "react";
 export type ScreenHeaderProps = {
 	onBack: () => void;
 	children: ReactNode;
+	/** Disables the Back button - for screens where navigating away mid-scan would abandon in-progress backend work with no way back to it. Defaults to false. */
+	disabled?: boolean;
 };
 
-export default function ScreenHeader({ onBack, children }: ScreenHeaderProps) {
+export default function ScreenHeader({ onBack, children, disabled = false }: ScreenHeaderProps) {
 	return (
 		<div className="flex w-full items-center justify-between">
 			<div className="group inline-flex items-center justify-start gap-x-0.5">
@@ -17,6 +19,7 @@ export default function ScreenHeader({ onBack, children }: ScreenHeaderProps) {
 					size="icon"
 					className="w-fit! gap-0.5 group-hover:text-accent"
 					onClick={onBack}
+					disabled={disabled}
 				>
 					<ChevronLeft
 						strokeWidth={1.5}


### PR DESCRIPTION
## Summary

- Found via manual testing of PR #57 (progressive file-scan delivery): the Back button on the results screen (`IssuesOverviewList`) stayed enabled during an in-progress scan (single-page or file). Clicking it navigated to `INDEX` and cleared `detectedIssues` while the backend kept scanning in the background, with no way back to the results once it finished.
- Pre-existing for plain single-page scans too, just more noticeable now that a file scan can run considerably longer.
- `ScreenHeader` gains an optional `disabled` prop (defaults to `false`, so `IssuesWrapper`'s own usage — which has no `scanning` concept — is unaffected). `IssuesOverviewList` wires it to the existing `scanning` store flag.

## Test plan
- [x] `npx tsc -b`
- [x] `npm run lint`
- [x] `npm run test` (385/385 passing, including new coverage: `ScreenHeader` disabled/enabled states, `IssuesOverviewList`'s Back button disabled while scanning and re-enabled once it finishes)
- [x] `npm run build`
- [x] Mutation-tested the `disabled` wiring (removed the prop, confirmed exactly the two new tests fail, restored) to confirm the tests actually catch a regression