### PR TITLE
test(scan): lock in Back-button safety during a mid-file-scan drill-in

### DIFF
--- a/src/components/organisms/IssuesWrapper/index.test.tsx
+++ b/src/components/organisms/IssuesWrapper/index.test.tsx
@@ -93,6 +93,30 @@ describe("IssuesWrapper", () => {
 		expect(useIssuesStore.getState().currentRoute).toBe("ISSUE_OVERVIEW_LIST_VIEW");
 	});
 
+	it("returns to the overview, not INDEX, when the back button is clicked mid-file-scan (regression guard)", async () => {
+		// A file scan streams results in on the App-level listener regardless of
+		// which screen is mounted (see App/index.tsx), so it's safe for this
+		// screen's back button to stay unguarded during a scan - unlike
+		// IssuesOverviewList's back button (which does go to INDEX and is
+		// disabled while scanning, see ScreenHeader's disabled prop), this one
+		// only ever navigates to ISSUE_OVERVIEW_LIST_VIEW outside quick-check
+		// mode, so detectedIssues/scanning are never at risk of being lost here.
+		const user = userEvent.setup();
+		useIssuesStore.setState({
+			selectedType: "TYPOGRAPHY",
+			scanning: true,
+			isFileScan: true,
+			detectedIssues: [typographyIssue],
+		});
+		render(<IssuesWrapper>child</IssuesWrapper>);
+
+		await user.click(screen.getByRole("button", { name: "Back" }));
+
+		expect(useIssuesStore.getState().currentRoute).toBe("ISSUE_OVERVIEW_LIST_VIEW");
+		expect(useIssuesStore.getState().scanning).toBe(true);
+		expect(useIssuesStore.getState().detectedIssues).toEqual([typographyIssue]);
+	});
+
 	it("cancels the quick check and returns to INDEX when quick-check is active", async () => {
 		const user = userEvent.setup();
 		useIssuesStore.setState({


### PR DESCRIPTION
## Summary
- Closes out one of the two "known gaps" left open by #57's progressive-file-scan plan: the concern that navigating back mid-scan could clear `detectedIssues` while a file scan kept streaming pages invisibly in the background.
- No product code change needed — that path is already closed by #58 (`db55a63`), which disabled `IssuesOverviewList`'s Back button while `scanning` is true. That was the only route to `INDEX` during a scan; `IssuesWrapper`'s own Back button (reached by drilling into an issue) was deliberately left unguarded in that same commit, since outside quick-check mode it only ever returns to `ISSUE_OVERVIEW_LIST_VIEW`, never `INDEX`.
- Adds a regression test locking this in: clicking Back from an issue's detail view mid-file-scan lands on `ISSUE_OVERVIEW_LIST_VIEW`, and `scanning`/`detectedIssues` are untouched.
- Verified via mutation testing: reverted `handleBackBtnClick` to unconditionally navigate to `INDEX` and clear state, confirmed the new test (and two pre-existing ones) failed, then restored and confirmed all pass again.

## Test plan
- [x] `npx tsc -b`
- [x] `npm run lint`
- [x] `npm run test` — 401/401
- [x] `npm run build`
- [x] Mutation-tested the new assertion against a deliberately reintroduced bug