### PR TITLE
fix(scan): guard handleScanFile against concurrent invocations

### DIFF
--- a/plugin/code.ts
+++ b/plugin/code.ts
@@ -257,62 +257,89 @@ function handleCancelScan() {
 	setIsPageScanCancelled(true);
 }
 
+// Guards against two overlapping handleScanFile runs interleaving writes to
+// the shared isFileScanCancelled flag and each other's postMessage streams.
+// Not reachable through the UI today - ScanModeSplitButton already disables
+// both scan triggers while scanning === true - but that's a UI-side
+// guarantee, not one this function can rely on; a second SCAN_FILE message
+// arriving mid-scan (e.g. a future caller, or the guard above changing)
+// should be ignored rather than silently corrupt the in-flight scan.
+let isFileScanInProgress = false;
+
 // Scans every page in the file, not just the current one. documentAccess is
 // "dynamic-page" (manifest.json), so every page other than figma.currentPage
 // needs an explicit PageNode.loadAsync() before it can be traversed -
 // figma.root.children itself is available synchronously without loading
 // anything, so the page list (names/count) can be enumerated up front.
 async function handleScanFile(message: ScanSettings) {
-	const deviceType = message.deviceType ?? "touch";
-	const targetLevel = message.targetLevel ?? "AA";
-	setScanSettings({ deviceType, targetLevel });
-	setIsFileScanCancelled(false);
+	if (isFileScanInProgress) {
+		console.warn("Ignored SCAN_FILE: a file scan is already in progress.");
+		return;
+	}
+	isFileScanInProgress = true;
 
-	// Scan the page the user is currently looking at first, then the rest of
-	// the file in file order - this is what makes streaming worthwhile, since
-	// the first results to land are for the page the user is actually on.
-	const currentPage = figma.currentPage;
-	const pages = [
-		currentPage,
-		...figma.root.children.filter((page) => page.id !== currentPage.id),
-	];
+	try {
+		const deviceType = message.deviceType ?? "touch";
+		const targetLevel = message.targetLevel ?? "AA";
+		setScanSettings({ deviceType, targetLevel });
+		setIsFileScanCancelled(false);
 
-	for (let i = 0; i < pages.length; i++) {
-		if (getIsFileScanCancelled()) break;
+		// Scan the page the user is currently looking at first, then the rest
+		// of the file in file order - this is what makes streaming worthwhile,
+		// since the first results to land are for the page the user is
+		// actually on.
+		const currentPage = figma.currentPage;
+		const pages = [
+			currentPage,
+			...figma.root.children.filter((page) => page.id !== currentPage.id),
+		];
 
-		const page = pages[i];
-		await page.loadAsync();
+		for (let i = 0; i < pages.length; i++) {
+			if (getIsFileScanCancelled()) break;
 
-		const allTextNodes = page.findAll(
-			(node) => node.type === "TEXT" && isScannable(node),
-		) as TextNode[];
-		const allPageNodes = page.findAll((node) => isScannable(node)) as SceneNode[];
+			const page = pages[i];
+			await page.loadAsync();
 
-		const pageIssues = await collectIssues(allTextNodes, allPageNodes, deviceType, targetLevel);
-		const taggedPageIssues = tagIssuesWithPage(pageIssues, page.id, page.name);
+			const allTextNodes = page.findAll(
+				(node) => node.type === "TEXT" && isScannable(node),
+			) as TextNode[];
+			const allPageNodes = page.findAll((node) => isScannable(node)) as SceneNode[];
 
-		// Stream this page's results immediately instead of accumulating them
-		// in memory - each page's own array is naturally already a bounded
-		// chunk, so this is both progressive delivery and chunking at once.
-		if (taggedPageIssues.length > 0) {
-			postMessageToUI(MESSAGE_TYPES.SCAN_FILE_PAGE_ISSUES, taggedPageIssues);
+			const pageIssues = await collectIssues(
+				allTextNodes,
+				allPageNodes,
+				deviceType,
+				targetLevel,
+			);
+			const taggedPageIssues = tagIssuesWithPage(pageIssues, page.id, page.name);
+
+			// Stream this page's results immediately instead of accumulating
+			// them in memory - each page's own array is naturally already a
+			// bounded chunk, so this is both progressive delivery and chunking
+			// at once.
+			if (taggedPageIssues.length > 0) {
+				postMessageToUI(MESSAGE_TYPES.SCAN_FILE_PAGE_ISSUES, taggedPageIssues);
+			}
+
+			postMessageToUI(MESSAGE_TYPES.SCAN_FILE_PROGRESS, {
+				pageIndex: i + 1,
+				pageCount: pages.length,
+				pageName: page.name,
+			});
+
+			// Yield to the event loop so the messages above actually flush to
+			// the UI, and so a CANCEL_SCAN_FILE message sent while this page
+			// was being scanned gets processed before the next page starts.
+			await new Promise((resolve) => setTimeout(resolve, 0));
 		}
 
-		postMessageToUI(MESSAGE_TYPES.SCAN_FILE_PROGRESS, {
-			pageIndex: i + 1,
-			pageCount: pages.length,
-			pageName: page.name,
-		});
-
-		// Yield to the event loop so the messages above actually flush to the
-		// UI, and so a CANCEL_SCAN_FILE message sent while this page was being
-		// scanned gets processed before the next page starts.
-		await new Promise((resolve) => setTimeout(resolve, 0));
+		// Unconditional, same as the old final LOAD_ISSUES send - tells the UI
+		// the scan is over whether it finished naturally or was cancelled
+		// partway.
+		postMessageToUI(MESSAGE_TYPES.SCAN_FILE_COMPLETE, { cancelled: getIsFileScanCancelled() });
+	} finally {
+		isFileScanInProgress = false;
 	}
-
-	// Unconditional, same as the old final LOAD_ISSUES send - tells the UI the
-	// scan is over whether it finished naturally or was cancelled partway.
-	postMessageToUI(MESSAGE_TYPES.SCAN_FILE_COMPLETE, { cancelled: getIsFileScanCancelled() });
 }
 
 // Requests the loop above stop after its current page - a boolean gate


### PR DESCRIPTION
## Summary
- Closes the other "known gap" left open by #57's progressive-file-scan plan: no reentrancy guard on `handleScanFile`, so two overlapping `SCAN_FILE` calls could interleave writes to the shared `isFileScanCancelled` flag and each other's `postMessage` streams.
- Not reachable through the UI today — `ScanModeSplitButton` already disables both scan triggers while `scanning === true` — but that's a guarantee the UI happens to provide, not one `handleScanFile` should rely on to stay correct.
- Adds a module-level `isFileScanInProgress` flag around the scan loop (mirrors the existing `suppressNextSelectionChange` module-flag pattern already used in this file). A second `SCAN_FILE` arriving mid-scan is logged and ignored rather than corrupting the in-flight scan.

## Test plan
- [x] `npx tsc -b`
- [x] `npm run lint`
- [x] `npm run test` — 400/400
- [x] `npm run build`
- [ ] Not verifiable via Figma dev mode either — this guards a state impossible to reach through the real UI (the trigger button is already disabled while scanning). Correctness here rests on code review of the added flag, not a repro.