### PR TITLE
style(ui): tighten spacing and use semantic colour tokens in scan controls

### DIFF
--- a/src/components/organisms/AccessibilityValidator/index.tsx
+++ b/src/components/organisms/AccessibilityValidator/index.tsx
@@ -39,7 +39,7 @@ export default function AccessibilityValidator() {
 	};
 
 	return (
-		<div className="flex size-full flex-col space-y-5">
+		<div className="flex size-full flex-col space-y-4">
 			<div className="flex gap-2 pt-2">
 				<ScanModeSplitButton
 					scanning={scanning}
@@ -60,7 +60,7 @@ export default function AccessibilityValidator() {
 
 			<ScanSettingsReadout targetLevel={targetLevel} deviceType={deviceType} />
 
-			<div className="relative m-4">
+			<div className="relative m-4 -mt-0.5">
 				<div className="absolute inset-0 flex items-center">
 					<span className="w-full border-t border-rose-50/10" />
 				</div>

--- a/src/components/organisms/IssueDetailRow/index.tsx
+++ b/src/components/organisms/IssueDetailRow/index.tsx
@@ -16,7 +16,7 @@ export default function IssueDetailRow({ label, value, icon, tooltip }: IssueDet
 				{label}
 			</div>
 			<div className="flex items-center text-sm">
-				{typeof tooltip === "string" && <InfoPopover content={tooltip} align="center" />}
+				{typeof tooltip === "string" && <InfoPopover content={tooltip} />}
 				{value}
 			</div>
 		</div>

--- a/src/components/organisms/IssuesWrapper/index.tsx
+++ b/src/components/organisms/IssuesWrapper/index.tsx
@@ -222,7 +222,7 @@ export default function IssuesWrapper({ children }: { children: React.ReactNode 
 		return (
 			<>
 				{description && (
-					<p className="font-open-sans font-medium text-grey">{description}</p>
+					<p className="-mt-2! font-open-sans font-medium text-grey">{description}</p>
 				)}
 
 				{children}

--- a/src/components/organisms/ScanModeSplitButton/index.tsx
+++ b/src/components/organisms/ScanModeSplitButton/index.tsx
@@ -58,7 +58,7 @@ export default function ScanModeSplitButton({
 					title="More scan options"
 					aria-label="More scan options"
 					disabled={scanning}
-					className="relative flex h-full w-9 shrink-0 items-center justify-center rounded-l-none rounded-r-md border-l border-white/20 bg-accent text-white transition-colors hover:bg-[#2980b9] focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-dark-shade focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+					className="relative flex h-full w-9 shrink-0 items-center justify-center rounded-l-none rounded-r-md border-l border-primary-foreground/50 bg-accent text-primary-foreground transition-colors hover:bg-[#2980b9] focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-dark-shade focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
 				>
 					<ChevronDown aria-hidden="true" className="size-4" />
 					{!hasSeenFileScanOption && (


### PR DESCRIPTION
## Summary
- Tighten spacing in `AccessibilityValidator` and `IssuesWrapper`
- Drop redundant `align` prop on `IssueDetailRow`'s `InfoPopover`
- Swap hardcoded white colour classes for `primary-foreground` tokens in `ScanModeSplitButton`

## Test plan
- [x] Visual check in Figma dev mode: scan controls spacing and split-button colours