### PR TITLE
feat(scan): add WCAG success-criterion citations and a Markdown export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Two version numbers appear in this project and they are **not** the same thing:
 
 Versions 2-10's descriptions are transcribed as originally published on Figma - full commit-level detail for that period isn't available since this changelog was only introduced retroactively (06/08/2026).
 
+## [1.4.0] - Figma Version 15 (provisional - Figma's version number auto-increments on publish, confirm once actually published) - 10/08/2026
+
+### Added
+
+- Every exported issue now cites the specific WCAG success criterion it relates to (e.g. "WCAG 2.5.8 Target Size (Minimum) (AA)"), with a link to the official W3C page so you can verify it yourself - available in the CSV and JSON reports. Where no exact criterion exists (minimum font size has none in WCAG), the citation says so explicitly rather than guessing. (#64)
+- New Markdown export option alongside CSV/JSON - a readable report grouped by severity, with clickable WCAG citation links, better suited to pasting into a PR description or handoff doc than a spreadsheet dump. (#64)
+
 ## [1.3.0] - Figma Version 14 (provisional - Figma's version number auto-increments on publish, confirm once actually published) - 10/08/2026
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "MIT",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "commit": "commit",

--- a/src/components/organisms/ContrastFixSuggester/index.tsx
+++ b/src/components/organisms/ContrastFixSuggester/index.tsx
@@ -62,7 +62,7 @@ export default function ContrastFixSuggester({
 										: "Lighten"}{" "}
 									text
 								</span>
-								<span className="inline-flex items-center gap-x-1 font-mono text-green-500">
+								<span className="inline-flex items-center gap-x-1 font-mono font-semibold text-green-500">
 									<Check aria-hidden="true" className="size-4" />
 									{foregroundSuggestion.ratio.toFixed(2)}:1
 								</span>
@@ -110,7 +110,7 @@ export default function ContrastFixSuggester({
 										: "Lighten"}{" "}
 									background
 								</span>
-								<span className="inline-flex items-center gap-x-1 font-mono text-green-500">
+								<span className="inline-flex items-center gap-x-1 font-mono font-semibold text-green-500">
 									<Check aria-hidden="true" className="size-4" />
 									{backgroundSuggestion.ratio.toFixed(2)}:1
 								</span>

--- a/src/components/organisms/IssuesOverviewList/index.test.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.test.tsx
@@ -58,6 +58,13 @@ const contrastFailIssueWithApca: DetectedIssue = {
 	},
 };
 
+const touchTargetSpacingIssue: DetectedIssue = {
+	type: "TOUCH_TARGET_SPACING",
+	description: "Touch target elements are too close.",
+	severity: "minor",
+	nodeData: { id: "tt1", name: "Icon Button", nodeType: "FRAME" },
+};
+
 const defaultState = {
 	detectedIssues: [] as DetectedIssue[],
 	scanning: false,
@@ -435,6 +442,163 @@ describe("IssuesOverviewList", () => {
 		expect(content[0].apcaLc).toBe("N/A");
 		expect(content[0].apcaMeetsMinimum).toBe("N/A");
 		expect(content[0].wcagApcaDisagree).toBe("N/A");
+	});
+
+	it("includes a WCAG SC citation and its source URL in the CSV export, target-level aware", async () => {
+		const user = userEvent.setup();
+		useIssuesStore.setState({ detectedIssues: [contrastFailIssue], targetLevel: "AA" });
+		render(<IssuesOverviewList />);
+
+		await goToReportTab(user);
+		await user.click(screen.getByRole("button", { name: "Download CSV" }));
+
+		const blob = saveAs.mock.calls[0][0] as Blob;
+		const content = await blob.text();
+		const [header, firstRow] = content.split("\n");
+
+		expect(header).toContain("WCAG SC Citation,WCAG SC URL");
+		expect(firstRow).toContain("1.4.3");
+		expect(firstRow).toContain(
+			"https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html",
+		);
+	});
+
+	it("includes the same WCAG SC citation fields in the JSON export", async () => {
+		const user = userEvent.setup();
+		useIssuesStore.setState({ detectedIssues: [contrastFailIssue], targetLevel: "AAA" });
+		render(<IssuesOverviewList />);
+
+		await goToReportTab(user);
+		await user.click(screen.getByRole("button", { name: "Download JSON" }));
+
+		const blob = saveAs.mock.calls[0][0] as Blob;
+		const content = JSON.parse(await blob.text());
+
+		expect(content[0].wcagCitation).toBe("WCAG 1.4.6 Contrast (Enhanced) (AAA)");
+		expect(content[0].wcagCitationUrl).toBe(
+			"https://www.w3.org/WAI/WCAG22/Understanding/contrast-enhanced.html",
+		);
+	});
+
+	it("cites the same SC number and URL as touch-target size for a touch-target spacing issue", async () => {
+		const user = userEvent.setup();
+		useIssuesStore.setState({ detectedIssues: [touchTargetSpacingIssue], targetLevel: "AA" });
+		render(<IssuesOverviewList />);
+
+		await goToReportTab(user);
+		await user.click(screen.getByRole("button", { name: "Download JSON" }));
+
+		const blob = saveAs.mock.calls[0][0] as Blob;
+		const content = JSON.parse(await blob.text());
+
+		expect(content[0].wcagCitation).toContain("2.5.8");
+		expect(content[0].wcagCitation).toContain("spacing exception");
+		expect(content[0].wcagCitationUrl).toBe(
+			"https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html",
+		);
+	});
+
+	it("shows an explicit 'no exact SC' citation for typography, not a bare N/A", async () => {
+		const user = userEvent.setup();
+		useIssuesStore.setState({ detectedIssues: [typographyIssue] });
+		render(<IssuesOverviewList />);
+
+		await goToReportTab(user);
+		await user.click(screen.getByRole("button", { name: "Download JSON" }));
+
+		const blob = saveAs.mock.calls[0][0] as Blob;
+		const content = JSON.parse(await blob.text());
+
+		expect(content[0].wcagCitation).not.toBe("N/A");
+		expect(content[0].wcagCitation).toContain("No exact WCAG SC");
+		expect(content[0].wcagCitationUrl).toBe(
+			"https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html",
+		);
+	});
+
+	describe("Markdown export", () => {
+		it("downloads a Markdown report when 'Download Markdown' is clicked", async () => {
+			const user = userEvent.setup();
+			useIssuesStore.setState({ detectedIssues: [typographyIssue] });
+			render(<IssuesOverviewList />);
+
+			await goToReportTab(user);
+			await user.click(screen.getByRole("button", { name: "Download Markdown" }));
+
+			expect(saveAs).toHaveBeenCalledWith(expect.any(Blob), "accessibility-issues-report.md");
+		});
+
+		it("includes a top-level title and per-severity headings matching the detected issues", async () => {
+			const user = userEvent.setup();
+			useIssuesStore.setState({
+				detectedIssues: [typographyIssue, contrastFailIssue],
+			});
+			render(<IssuesOverviewList />);
+
+			await goToReportTab(user);
+			await user.click(screen.getByRole("button", { name: "Download Markdown" }));
+
+			const blob = saveAs.mock.calls[0][0] as Blob;
+			const content = await blob.text();
+
+			expect(content).toContain("# Accessibility Issues Report");
+			expect(content).toContain("## Critical");
+			expect(content).toContain("## Major");
+			expect(content).not.toContain("## Minor");
+		});
+
+		it("groups each issue under its own severity heading, not another one's", async () => {
+			const user = userEvent.setup();
+			useIssuesStore.setState({
+				detectedIssues: [typographyIssue, contrastFailIssue],
+			});
+			render(<IssuesOverviewList />);
+
+			await goToReportTab(user);
+			await user.click(screen.getByRole("button", { name: "Download Markdown" }));
+
+			const blob = saveAs.mock.calls[0][0] as Blob;
+			const content = await blob.text();
+
+			const criticalSection = content.split("## Critical")[1].split("## Major")[0];
+			const majorSection = content.split("## Major")[1];
+
+			expect(criticalSection).toContain("Text contrast is below WCAG AA standard.");
+			expect(criticalSection).not.toContain("Text size is too small for readability.");
+			expect(majorSection).toContain("Text size is too small for readability.");
+			expect(majorSection).not.toContain("Text contrast is below WCAG AA standard.");
+		});
+
+		it("renders the WCAG citation as a real Markdown link, not just plain text", async () => {
+			const user = userEvent.setup();
+			useIssuesStore.setState({ detectedIssues: [contrastFailIssue], targetLevel: "AA" });
+			render(<IssuesOverviewList />);
+
+			await goToReportTab(user);
+			await user.click(screen.getByRole("button", { name: "Download Markdown" }));
+
+			const blob = saveAs.mock.calls[0][0] as Blob;
+			const content = await blob.text();
+
+			expect(content).toContain(
+				"[WCAG 1.4.3 Contrast (Minimum) (AA)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)",
+			);
+		});
+
+		it("omits N/A fields from an issue's block instead of printing them", async () => {
+			const user = userEvent.setup();
+			useIssuesStore.setState({ detectedIssues: [typographyIssue] });
+			render(<IssuesOverviewList />);
+
+			await goToReportTab(user);
+			await user.click(screen.getByRole("button", { name: "Download Markdown" }));
+
+			const blob = saveAs.mock.calls[0][0] as Blob;
+			const content = await blob.text();
+
+			expect(content).not.toContain("WCAG contrast score");
+			expect(content).not.toContain("APCA");
+		});
 	});
 
 	describe("active settings readout", () => {

--- a/src/components/organisms/IssuesOverviewList/index.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.tsx
@@ -11,38 +11,35 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ISSUES_TYPES } from "@/lib/constants";
 import ISSUE_TYPE_LABELS from "@/lib/issueTypeLabels";
 import ISSUES_DATA_SCHEMA from "@/lib/issuesData";
-import { IssueType, DetectedIssue, Severity } from "@/lib/types";
+import { IssueType, DetectedIssue } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
+import { cn, getRouteForIssueType, getSeverityStyles, isActiveIssue } from "@/lib/utils";
 import {
-	cn,
-	contrastMethodsDisagree,
-	getContrastIssueDescription,
-	getRouteForIssueType,
-	getSeverityStyles,
-	isActiveIssue,
-} from "@/lib/utils";
-import getWcagCitation from "@/lib/wcagCitations";
-import { saveAs } from "file-saver";
+	formatIssuesForReport,
+	generateCSVReport,
+	generateJSONReport,
+	generateMarkdownReport,
+} from "@/lib/utils/reportExport";
 import { RefreshCcw } from "lucide-react";
 
 export default function IssuesOverviewList() {
 	const {
 		scanning,
 		detectedIssues,
-		setDetectedIssues,
-		setSelectedType,
-		navigateTo,
-		rescanIssues,
 		targetLevel,
-		setTargetLevel,
 		deviceType,
 		fileScanProgress,
 		isFileScan,
 		fileScanCancelled,
-		cancelFileScan,
 		pageScanCancelled,
-		cancelPageScan,
 		pageCount,
+		setTargetLevel,
+		cancelFileScan,
+		cancelPageScan,
+		setDetectedIssues,
+		setSelectedType,
+		navigateTo,
+		rescanIssues,
 	} = useIssuesStore();
 
 	const issuesGroupListRecords = detectedIssues.filter((issue) => {
@@ -68,173 +65,6 @@ export default function IssuesOverviewList() {
 		}))
 		.filter((item) => item.count > 0);
 
-	const formatIssuesForReport = () => {
-		return issuesGroupListRecords.map((issue) => {
-			const elementName =
-				issue.nodeData?.nodeType === "TEXT"
-					? issue.nodeData?.characters
-					: issue.nodeData?.name;
-
-			const description =
-				issue.type === "CONTRAST"
-					? getContrastIssueDescription(
-							issue.nodeData.contrastScore?.compliance,
-							targetLevel,
-						)
-					: issue.description;
-
-			return {
-				elementType: issue.nodeData?.nodeType || "N/A",
-				elementName: elementName || "N/A",
-				description,
-				severity: issue.severity,
-				type: (issue.type && ISSUE_TYPE_LABELS[issue.type]) || issue.type,
-				wcagCitation: issue.type
-					? getWcagCitation(issue.type, targetLevel).citation
-					: "N/A",
-				wcagCitationUrl: issue.type ? getWcagCitation(issue.type, targetLevel).url : "N/A",
-				wcagContrastScore: issue.nodeData?.contrastScore?.compliance || "N/A",
-				contrastRatio: issue.nodeData?.contrastScore?.ratio.toFixed(2) || "N/A",
-				apcaLc: issue.nodeData?.apcaScore
-					? Math.round(Math.abs(issue.nodeData.apcaScore.lc))
-					: "N/A",
-				apcaMeetsMinimum: issue.nodeData?.apcaScore
-					? issue.nodeData.apcaScore.meetsMinimum
-						? "Pass"
-						: "Fail"
-					: "N/A",
-				wcagApcaDisagree: issue.nodeData?.apcaScore
-					? contrastMethodsDisagree(
-							issue.nodeData.contrastScore?.compliance,
-							targetLevel,
-							issue.nodeData.apcaScore.meetsMinimum,
-						)
-						? "Yes"
-						: "No"
-					: "N/A",
-				fontSize: issue.nodeData?.fontSize || "N/A",
-			};
-		});
-	};
-
-	const generateCSV = () => {
-		const formattedIssues = formatIssuesForReport();
-		const csvHeader =
-			"Element Type,Element Name,Issue Type,WCAG SC Citation,WCAG SC URL,Description,Severity,WCAG Contrast Score, WCAG Contrast Ratio,APCA Lc,APCA Meets Minimum,WCAG/APCA Disagree,Font Size";
-
-		const csvRows = formattedIssues.map((issue) => {
-			return [
-				`"${issue.elementType || "N/A"}"`, // Element Type
-				`"${issue.elementName}"`, // Element Name
-				`"${issue.type || "N/A"}"`, // Issue Type
-				`"${issue.wcagCitation || "N/A"}"`, // WCAG SC Citation
-				`"${issue.wcagCitationUrl || "N/A"}"`, // WCAG SC URL
-				`"${issue.description || ""}"`, // Description
-				`"${issue.severity || "N/A"}"`, // Severity
-				`"${issue.wcagContrastScore || "N/A"}"`, // WCAG Score
-				`"${issue.contrastRatio || "N/A"}"`, // Contrast ratio
-				`"${issue.apcaLc}"`, // APCA Lc
-				`"${issue.apcaMeetsMinimum}"`, // APCA Meets Minimum
-				`"${issue.wcagApcaDisagree}"`, // WCAG/APCA Disagree
-				`"${issue.fontSize || "N/A"}"`, // Font Size
-			].join(",");
-		});
-
-		// Join the header and rows to form the CSV content
-		const csvContent = [csvHeader, ...csvRows].join("\n");
-
-		const csvBlob = new Blob([csvContent], { type: "text/csv" });
-
-		saveAs(csvBlob, "accessibility-issues-report.csv");
-	};
-
-	const generateJSON = () => {
-		const formattedIssues = formatIssuesForReport();
-		const jsonBlob = new Blob([JSON.stringify(formattedIssues, null, 2)], {
-			type: "application/json",
-		});
-		saveAs(jsonBlob, "accessibility-issues-report.json");
-	};
-
-	// Reuses formatIssuesForReport as its sole data source, same as
-	// generateCSV/generateJSON - no duplicated issue-formatting logic. Unlike
-	// those two flat table dumps, this reads as a genuine document: issues are
-	// grouped by severity (critical first) rather than issue type, since
-	// dev-handoff triage is severity-first, and the WCAG citation renders as a
-	// real clickable link rather than plain text.
-	const generateMarkdown = () => {
-		const formattedIssues = formatIssuesForReport();
-		const scope = isFileScan ? "across this file" : "on this page";
-		const generatedOn = new Date().toLocaleDateString("en-GB");
-		const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
-
-		const severityOrder: Severity[] = ["critical", "major", "minor"];
-		const bySeverity = severityOrder.map((severity) => ({
-			severity,
-			issues: formattedIssues.filter((issue) => issue.severity === severity),
-		}));
-
-		const lines: string[] = [
-			"# Accessibility Issues Report",
-			"",
-			`Generated ${generatedOn} - ${formattedIssues.length} issue${formattedIssues.length === 1 ? "" : "s"} detected ${scope}.`,
-			"",
-			"## Summary",
-			"",
-			"| Severity | Count |",
-			"|---|---|",
-			...bySeverity.map(
-				({ severity, issues }) => `| ${capitalize(severity)} | ${issues.length} |`,
-			),
-			"",
-		];
-
-		bySeverity.forEach(({ severity, issues }) => {
-			if (issues.length === 0) return;
-
-			lines.push(`## ${capitalize(severity)}`, "");
-
-			issues.forEach((issue, index) => {
-				lines.push(`### ${index + 1}. ${issue.type} - ${issue.elementName}`, "");
-				lines.push(`- **Element type:** ${issue.elementType}`);
-
-				const citationText =
-					issue.wcagCitationUrl !== "N/A"
-						? `[${issue.wcagCitation}](${issue.wcagCitationUrl})`
-						: issue.wcagCitation;
-				lines.push(`- **WCAG citation:** ${citationText}`);
-
-				lines.push(`- **Description:** ${issue.description}`);
-
-				if (issue.wcagContrastScore !== "N/A") {
-					lines.push(
-						`- **WCAG contrast score:** ${issue.wcagContrastScore} (ratio ${issue.contrastRatio}:1)`,
-					);
-				}
-				if (issue.apcaLc !== "N/A") {
-					lines.push(
-						`- **APCA:** Lc ${issue.apcaLc} (${issue.apcaMeetsMinimum}) - WCAG/APCA disagree: ${issue.wcagApcaDisagree}`,
-					);
-				}
-				if (issue.fontSize !== "N/A") {
-					lines.push(`- **Font size:** ${issue.fontSize}px`);
-				}
-
-				lines.push("");
-			});
-		});
-
-		const markdownBlob = new Blob([lines.join("\n")], { type: "text/markdown" });
-		saveAs(markdownBlob, "accessibility-issues-report.md");
-	};
-
-	// True once there's something worth showing - either the scan is fully
-	// done, or it's a file scan whose first page has already streamed in.
-	// fileScanProgress only ever becomes non-null after a page's progress
-	// message arrives, and that page's SCAN_FILE_PAGE_ISSUES is always sent
-	// (and processed, given in-order postMessage delivery) before its
-	// SCAN_FILE_PROGRESS - so this is a reliable "first page already landed"
-	// signal without needing a separate counter.
 	const showResults = !scanning || (isFileScan && fileScanProgress !== null);
 
 	return (
@@ -428,21 +258,43 @@ export default function IssuesOverviewList() {
 								<Button
 									title="Download CSV Report"
 									variant="default"
-									onClick={generateCSV}
+									onClick={() =>
+										generateCSVReport(
+											formatIssuesForReport(
+												issuesGroupListRecords,
+												targetLevel,
+											),
+										)
+									}
 								>
 									Download CSV
 								</Button>
 								<Button
 									title="Download JSON Report"
 									variant="default"
-									onClick={generateJSON}
+									onClick={() =>
+										generateJSONReport(
+											formatIssuesForReport(
+												issuesGroupListRecords,
+												targetLevel,
+											),
+										)
+									}
 								>
 									Download JSON
 								</Button>
 								<Button
 									title="Download Markdown Report"
 									variant="default"
-									onClick={generateMarkdown}
+									onClick={() =>
+										generateMarkdownReport(
+											formatIssuesForReport(
+												issuesGroupListRecords,
+												targetLevel,
+											),
+											isFileScan,
+										)
+									}
 								>
 									Download Markdown
 								</Button>

--- a/src/components/organisms/IssuesOverviewList/index.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.tsx
@@ -11,7 +11,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ISSUES_TYPES } from "@/lib/constants";
 import ISSUE_TYPE_LABELS from "@/lib/issueTypeLabels";
 import ISSUES_DATA_SCHEMA from "@/lib/issuesData";
-import { IssueType, DetectedIssue } from "@/lib/types";
+import { IssueType, DetectedIssue, Severity } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
 import {
 	cn,
@@ -21,6 +21,7 @@ import {
 	getSeverityStyles,
 	isActiveIssue,
 } from "@/lib/utils";
+import getWcagCitation from "@/lib/wcagCitations";
 import { saveAs } from "file-saver";
 import { RefreshCcw } from "lucide-react";
 
@@ -88,6 +89,10 @@ export default function IssuesOverviewList() {
 				description,
 				severity: issue.severity,
 				type: (issue.type && ISSUE_TYPE_LABELS[issue.type]) || issue.type,
+				wcagCitation: issue.type
+					? getWcagCitation(issue.type, targetLevel).citation
+					: "N/A",
+				wcagCitationUrl: issue.type ? getWcagCitation(issue.type, targetLevel).url : "N/A",
 				wcagContrastScore: issue.nodeData?.contrastScore?.compliance || "N/A",
 				contrastRatio: issue.nodeData?.contrastScore?.ratio.toFixed(2) || "N/A",
 				apcaLc: issue.nodeData?.apcaScore
@@ -115,13 +120,15 @@ export default function IssuesOverviewList() {
 	const generateCSV = () => {
 		const formattedIssues = formatIssuesForReport();
 		const csvHeader =
-			"Element Type,Element Name,Issue Type,Description,Severity,WCAG Contrast Score, WCAG Contrast Ratio,APCA Lc,APCA Meets Minimum,WCAG/APCA Disagree,Font Size";
+			"Element Type,Element Name,Issue Type,WCAG SC Citation,WCAG SC URL,Description,Severity,WCAG Contrast Score, WCAG Contrast Ratio,APCA Lc,APCA Meets Minimum,WCAG/APCA Disagree,Font Size";
 
 		const csvRows = formattedIssues.map((issue) => {
 			return [
 				`"${issue.elementType || "N/A"}"`, // Element Type
 				`"${issue.elementName}"`, // Element Name
 				`"${issue.type || "N/A"}"`, // Issue Type
+				`"${issue.wcagCitation || "N/A"}"`, // WCAG SC Citation
+				`"${issue.wcagCitationUrl || "N/A"}"`, // WCAG SC URL
 				`"${issue.description || ""}"`, // Description
 				`"${issue.severity || "N/A"}"`, // Severity
 				`"${issue.wcagContrastScore || "N/A"}"`, // WCAG Score
@@ -147,6 +154,78 @@ export default function IssuesOverviewList() {
 			type: "application/json",
 		});
 		saveAs(jsonBlob, "accessibility-issues-report.json");
+	};
+
+	// Reuses formatIssuesForReport as its sole data source, same as
+	// generateCSV/generateJSON - no duplicated issue-formatting logic. Unlike
+	// those two flat table dumps, this reads as a genuine document: issues are
+	// grouped by severity (critical first) rather than issue type, since
+	// dev-handoff triage is severity-first, and the WCAG citation renders as a
+	// real clickable link rather than plain text.
+	const generateMarkdown = () => {
+		const formattedIssues = formatIssuesForReport();
+		const scope = isFileScan ? "across this file" : "on this page";
+		const generatedOn = new Date().toLocaleDateString("en-GB");
+		const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
+
+		const severityOrder: Severity[] = ["critical", "major", "minor"];
+		const bySeverity = severityOrder.map((severity) => ({
+			severity,
+			issues: formattedIssues.filter((issue) => issue.severity === severity),
+		}));
+
+		const lines: string[] = [
+			"# Accessibility Issues Report",
+			"",
+			`Generated ${generatedOn} - ${formattedIssues.length} issue${formattedIssues.length === 1 ? "" : "s"} detected ${scope}.`,
+			"",
+			"## Summary",
+			"",
+			"| Severity | Count |",
+			"|---|---|",
+			...bySeverity.map(
+				({ severity, issues }) => `| ${capitalize(severity)} | ${issues.length} |`,
+			),
+			"",
+		];
+
+		bySeverity.forEach(({ severity, issues }) => {
+			if (issues.length === 0) return;
+
+			lines.push(`## ${capitalize(severity)}`, "");
+
+			issues.forEach((issue, index) => {
+				lines.push(`### ${index + 1}. ${issue.type} - ${issue.elementName}`, "");
+				lines.push(`- **Element type:** ${issue.elementType}`);
+
+				const citationText =
+					issue.wcagCitationUrl !== "N/A"
+						? `[${issue.wcagCitation}](${issue.wcagCitationUrl})`
+						: issue.wcagCitation;
+				lines.push(`- **WCAG citation:** ${citationText}`);
+
+				lines.push(`- **Description:** ${issue.description}`);
+
+				if (issue.wcagContrastScore !== "N/A") {
+					lines.push(
+						`- **WCAG contrast score:** ${issue.wcagContrastScore} (ratio ${issue.contrastRatio}:1)`,
+					);
+				}
+				if (issue.apcaLc !== "N/A") {
+					lines.push(
+						`- **APCA:** Lc ${issue.apcaLc} (${issue.apcaMeetsMinimum}) - WCAG/APCA disagree: ${issue.wcagApcaDisagree}`,
+					);
+				}
+				if (issue.fontSize !== "N/A") {
+					lines.push(`- **Font size:** ${issue.fontSize}px`);
+				}
+
+				lines.push("");
+			});
+		});
+
+		const markdownBlob = new Blob([lines.join("\n")], { type: "text/markdown" });
+		saveAs(markdownBlob, "accessibility-issues-report.md");
 	};
 
 	// True once there's something worth showing - either the scan is fully
@@ -359,6 +438,13 @@ export default function IssuesOverviewList() {
 									onClick={generateJSON}
 								>
 									Download JSON
+								</Button>
+								<Button
+									title="Download Markdown Report"
+									variant="default"
+									onClick={generateMarkdown}
+								>
+									Download Markdown
 								</Button>
 							</div>
 						</TabsContent>

--- a/src/components/organisms/IssuesOverviewList/index.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.tsx
@@ -424,7 +424,7 @@ export default function IssuesOverviewList() {
 								</div>
 							)}
 
-							<div className="space-x-3">
+							<div className="flex flex-wrap gap-3">
 								<Button
 									title="Download CSV Report"
 									variant="default"

--- a/src/components/organisms/IssuesWrapper/index.test.tsx
+++ b/src/components/organisms/IssuesWrapper/index.test.tsx
@@ -265,6 +265,36 @@ describe("IssuesWrapper", () => {
 		expect(screen.getByText("Recommendations")).toBeVisible();
 	});
 
+	it("passes a WCAG citation matching the current target level down to Recommendations", () => {
+		useIssuesStore.setState({
+			selectedType: "CONTRAST",
+			detectedIssues: [contrastFailIssue],
+			targetLevel: "AA",
+		});
+		const { rerender } = render(<IssuesWrapper>child</IssuesWrapper>);
+
+		expect(
+			screen.getByRole("link", {
+				name: /WCAG 1\.4\.3 Contrast \(Minimum\) \(AA\).*opens in a new tab/,
+			}),
+		).toHaveAttribute(
+			"href",
+			"https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html",
+		);
+
+		useIssuesStore.setState({ targetLevel: "AAA" });
+		rerender(<IssuesWrapper>child</IssuesWrapper>);
+
+		expect(
+			screen.getByRole("link", {
+				name: /WCAG 1\.4\.6 Contrast \(Enhanced\) \(AAA\).*opens in a new tab/,
+			}),
+		).toHaveAttribute(
+			"href",
+			"https://www.w3.org/WAI/WCAG22/Understanding/contrast-enhanced.html",
+		);
+	});
+
 	it("describes a genuine AA contrast failure as below WCAG AA standard", () => {
 		useIssuesStore.setState({
 			selectedType: "CONTRAST",

--- a/src/components/organisms/IssuesWrapper/index.tsx
+++ b/src/components/organisms/IssuesWrapper/index.tsx
@@ -12,6 +12,7 @@ import ISSUES_DATA_SCHEMA from "@/lib/issuesData";
 import { IssueType, DetectedIssue } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
 import { cn, getContrastIssueDescription, getRouteForIssueType, isActiveIssue } from "@/lib/utils";
+import getWcagCitation from "@/lib/wcagCitations";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -189,6 +190,7 @@ export default function IssuesWrapper({ children }: { children: React.ReactNode 
 		targetLevel,
 		activeIssue?.nodeData?.requiredSizePx,
 	);
+	const citation = selectedType ? getWcagCitation(selectedType, targetLevel) : null;
 
 	const renderWrapper = (issue: typeof singleIssue | null) => {
 		if (!issue) {
@@ -227,7 +229,7 @@ export default function IssuesWrapper({ children }: { children: React.ReactNode 
 
 				{children}
 
-				<Recommendations recommendations={suggestions || []} />
+				<Recommendations recommendations={suggestions || []} citation={citation} />
 			</>
 		);
 	};

--- a/src/components/organisms/Recommendations/index.test.tsx
+++ b/src/components/organisms/Recommendations/index.test.tsx
@@ -44,4 +44,86 @@ describe("Recommendations", () => {
 
 		expect(screen.getByRole("list")).toBeVisible();
 	});
+
+	describe("citation", () => {
+		const citation = {
+			exact: true,
+			citation: "WCAG 1.4.3 Contrast (Minimum) (AA)",
+			url: "https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html",
+		};
+		// The rendered link appends a visually-hidden "(opens in a new tab)"
+		// suffix, which is part of its computed accessible name - matched via
+		// regex since accessible-name computation collapses the whitespace
+		// between the citation text and the sr-only suffix.
+		const linkAccessibleName = /WCAG 1\.4\.3 Contrast \(Minimum\) \(AA\).*opens in a new tab/;
+
+		it("does not render a citation link when none is given", () => {
+			render(<Recommendations recommendations={["Improve contrast."]} />);
+
+			expect(screen.queryByRole("link")).toBeNull();
+		});
+
+		it("renders the citation as a link even while the recommendations list is collapsed", () => {
+			render(
+				<Recommendations
+					recommendations={["Improve contrast.", "Use a larger font size."]}
+					citation={citation}
+				/>,
+			);
+
+			const link = screen.getByRole("link", { name: linkAccessibleName });
+			expect(link).toBeVisible();
+			expect(screen.queryByRole("list")).toBeNull();
+		});
+
+		it("points the citation link at the official source with a safe target", () => {
+			render(<Recommendations recommendations={["Improve contrast."]} citation={citation} />);
+
+			const link = screen.getByRole("link", { name: linkAccessibleName });
+			expect(link).toHaveAttribute(
+				"href",
+				"https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html",
+			);
+			expect(link).toHaveAttribute("target", "_blank");
+			expect(link).toHaveAttribute("rel", "noopener noreferrer");
+		});
+
+		it("tells screen-reader users the link opens in a new tab", () => {
+			render(<Recommendations recommendations={["Improve contrast."]} citation={citation} />);
+
+			const link = screen.getByRole("link", { name: linkAccessibleName });
+			expect(link).toHaveTextContent("(opens in a new tab)");
+		});
+
+		it("clicking the citation link does not also toggle the recommendations list open", async () => {
+			const user = userEvent.setup();
+			render(
+				<Recommendations
+					recommendations={["Improve contrast.", "Use a larger font size."]}
+					citation={citation}
+				/>,
+			);
+
+			await user.click(screen.getByRole("link", { name: linkAccessibleName }));
+
+			expect(screen.queryByRole("list")).toBeNull();
+		});
+
+		it("activating the citation link via the keyboard does not also toggle the recommendations list open", async () => {
+			const user = userEvent.setup();
+			render(
+				<Recommendations
+					recommendations={["Improve contrast.", "Use a larger font size."]}
+					citation={citation}
+				/>,
+			);
+
+			await user.tab();
+			expect(screen.getByRole("link", { name: linkAccessibleName })).toHaveFocus();
+
+			await user.keyboard("{Enter}");
+
+			expect(screen.queryByRole("list")).toBeNull();
+		});
+	});
 });

--- a/src/components/organisms/Recommendations/index.tsx
+++ b/src/components/organisms/Recommendations/index.tsx
@@ -7,12 +7,6 @@ import { useState } from "react";
 
 export type RecommendationsProps = {
 	recommendations: string[];
-	/**
-	 * Shown as a link under the "Recommendations" heading, in the trigger row
-	 * itself rather than inside CollapsibleContent - so it stays visible even
-	 * while collapsed, unlike the recommendation bullets it sits above. Optional
-	 * since not every caller resolves a citation (e.g. no selectedType yet).
-	 */
 	citation?: WcagCitation | null;
 };
 

--- a/src/components/organisms/Recommendations/index.tsx
+++ b/src/components/organisms/Recommendations/index.tsx
@@ -1,17 +1,51 @@
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { WcagCitation } from "@/lib/wcagCitations";
+import { ChevronDown, ExternalLink } from "lucide-react";
 import { useState } from "react";
 
-export default function Recommendations({ recommendations }: { recommendations: string[] }) {
+export type RecommendationsProps = {
+	recommendations: string[];
+	/**
+	 * Shown as a link under the "Recommendations" heading, in the trigger row
+	 * itself rather than inside CollapsibleContent - so it stays visible even
+	 * while collapsed, unlike the recommendation bullets it sits above. Optional
+	 * since not every caller resolves a citation (e.g. no selectedType yet).
+	 */
+	citation?: WcagCitation | null;
+};
+
+export default function Recommendations({ recommendations, citation }: RecommendationsProps) {
 	const [open, setOpen] = useState(false);
 	if (!recommendations || recommendations.length === 0) return null;
 
 	return (
 		<Collapsible open={open} onOpenChange={setOpen} className="w-full">
 			<CollapsibleTrigger asChild>
-				<div className="flex cursor-pointer items-center justify-between space-x-4 rounded-md border border-rose-50/20 px-4 py-2">
-					<h4 className="font-open-sans text-sm font-semibold">Recommendations</h4>
+				<div
+					className={cn(
+						"flex cursor-pointer items-center justify-between gap-x-2 rounded-md border border-rose-50/20 px-3 py-2",
+						{ "rounded-b-none border-b-0!": open },
+					)}
+				>
+					<div>
+						<h4 className="font-open-sans text-sm font-semibold">Recommendations</h4>
+						{citation && (
+							<a
+								href={citation.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={(event) => event.stopPropagation()}
+								className="mt-0.5 inline-flex items-center gap-1 rounded-sm text-xs text-accent underline decoration-accent/40 underline-offset-2 hover:decoration-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-dark-shade focus-visible:outline-hidden"
+							>
+								{citation.citation}
+								<span className="sr-only"> (opens in a new tab)</span>
+
+								<ExternalLink aria-hidden="true" className="size-4" />
+							</a>
+						)}
+					</div>
 					<Button title="View recommendations" variant="nude" size="sm">
 						<ChevronDown
 							aria-hidden="true"
@@ -22,7 +56,11 @@ export default function Recommendations({ recommendations }: { recommendations: 
 				</div>
 			</CollapsibleTrigger>
 
-			<CollapsibleContent className="my-2">
+			<CollapsibleContent
+				className={cn("rounded-md border border-rose-50/20", {
+					"rounded-t-none border-t-0!": open,
+				})}
+			>
 				<div className="p-2.5 text-sm">
 					{recommendations.length === 1 ? (
 						<p>{recommendations[0]}</p>

--- a/src/lib/utils/reportExport/index.test.ts
+++ b/src/lib/utils/reportExport/index.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DetectedIssue } from "@/lib/types";
+
+const { saveAs } = vi.hoisted(() => ({ saveAs: vi.fn() }));
+
+vi.mock("file-saver", () => ({ saveAs }));
+
+beforeEach(() => {
+	saveAs.mockClear();
+});
+
+import {
+	formatIssuesForReport,
+	generateCSVReport,
+	generateJSONReport,
+	generateMarkdownReport,
+} from "./index";
+
+const typographyIssue: DetectedIssue = {
+	type: "TYPOGRAPHY",
+	description: "Text size is too small for readability.",
+	severity: "major",
+	nodeData: { id: "t1", name: "Label", nodeType: "TEXT" },
+};
+
+const contrastFailIssue: DetectedIssue = {
+	type: "CONTRAST",
+	description: "Text contrast is below WCAG AA standard.",
+	severity: "critical",
+	nodeData: {
+		id: "c1",
+		name: "Text",
+		nodeType: "TEXT",
+		contrastScore: { compliance: "Fail", ratio: 2 },
+	},
+};
+
+describe("formatIssuesForReport", () => {
+	it("derives a target-level-aware contrast description instead of the raw scan-time one", () => {
+		const passingAtAA: DetectedIssue = {
+			...contrastFailIssue,
+			nodeData: {
+				...contrastFailIssue.nodeData,
+				contrastScore: { compliance: "AA", ratio: 5 },
+			},
+		};
+
+		const [formatted] = formatIssuesForReport([passingAtAA], "AAA");
+
+		expect(formatted.description).toBe(
+			"Text contrast meets WCAG AA but is below the stricter WCAG AAA standard.",
+		);
+	});
+
+	it("reports 'N/A' for APCA fields on a non-CONTRAST issue", () => {
+		const [formatted] = formatIssuesForReport([typographyIssue], "AA");
+
+		expect(formatted.apcaLc).toBe("N/A");
+		expect(formatted.apcaMeetsMinimum).toBe("N/A");
+		expect(formatted.wcagApcaDisagree).toBe("N/A");
+	});
+
+	it("includes the WCAG SC citation and URL for the given target level", () => {
+		const [formatted] = formatIssuesForReport([contrastFailIssue], "AA");
+
+		expect(formatted.wcagCitation).toBe("WCAG 1.4.3 Contrast (Minimum) (AA)");
+		expect(formatted.wcagCitationUrl).toBe(
+			"https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html",
+		);
+	});
+});
+
+describe("generateCSVReport", () => {
+	it("saves a CSV blob with a header row and one quoted row per issue", async () => {
+		generateCSVReport(formatIssuesForReport([typographyIssue], "AA"));
+
+		expect(saveAs).toHaveBeenCalledWith(expect.any(Blob), "accessibility-issues-report.csv");
+		const blob = saveAs.mock.calls[0][0] as Blob;
+		const [header, firstRow] = (await blob.text()).split("\n");
+
+		expect(header).toContain("Element Type,Element Name,Issue Type");
+		expect(firstRow).toContain('"Typography"');
+	});
+});
+
+describe("generateJSONReport", () => {
+	it("saves a JSON blob containing the formatted issues", async () => {
+		generateJSONReport(formatIssuesForReport([typographyIssue], "AA"));
+
+		expect(saveAs).toHaveBeenCalledWith(expect.any(Blob), "accessibility-issues-report.json");
+		const blob = saveAs.mock.calls[0][0] as Blob;
+		const content = JSON.parse(await blob.text());
+
+		expect(content[0].description).toBe("Text size is too small for readability.");
+	});
+});
+
+describe("generateMarkdownReport", () => {
+	it("groups issues under a severity heading and links the WCAG citation", async () => {
+		generateMarkdownReport(formatIssuesForReport([contrastFailIssue], "AA"), false);
+
+		expect(saveAs).toHaveBeenCalledWith(expect.any(Blob), "accessibility-issues-report.md");
+		const blob = saveAs.mock.calls[0][0] as Blob;
+		const content = await blob.text();
+
+		expect(content).toContain("## Critical");
+		expect(content).toContain(
+			"[WCAG 1.4.3 Contrast (Minimum) (AA)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)",
+		);
+	});
+
+	it("says 'across this file' when isFileScan is true", async () => {
+		generateMarkdownReport(formatIssuesForReport([typographyIssue], "AA"), true);
+
+		const blob = saveAs.mock.calls[0][0] as Blob;
+		const content = await blob.text();
+
+		expect(content).toContain("across this file");
+	});
+});

--- a/src/lib/utils/reportExport/index.ts
+++ b/src/lib/utils/reportExport/index.ts
@@ -1,0 +1,175 @@
+import { saveAs } from "file-saver";
+import ISSUE_TYPE_LABELS from "@/lib/issueTypeLabels";
+import { DetectedIssue, Severity, TargetLevel } from "@/lib/types";
+import { contrastMethodsDisagree, getContrastIssueDescription } from "@/lib/utils";
+import getWcagCitation from "@/lib/wcagCitations";
+
+export type FormattedIssue = {
+	elementType: NodeType | NodeType[] | "N/A";
+	elementName: string;
+	description: string | undefined;
+	severity: Severity;
+	type: string | undefined;
+	wcagCitation: string;
+	wcagCitationUrl: string;
+	wcagContrastScore: string;
+	contrastRatio: string;
+	apcaLc: number | "N/A";
+	apcaMeetsMinimum: "Pass" | "Fail" | "N/A";
+	wcagApcaDisagree: "Yes" | "No" | "N/A";
+	fontSize: number | "N/A";
+};
+
+/**
+ * Shapes detected issues into the flat record used by all three report
+ * exports (CSV/JSON/Markdown) - computed at export time (not baked into the
+ * issue at scan time) so contrast target-level filtering and WCAG citations
+ * always reflect whichever target level is currently selected.
+ */
+export function formatIssuesForReport(
+	issues: DetectedIssue[],
+	targetLevel: TargetLevel,
+): FormattedIssue[] {
+	return issues.map((issue) => {
+		const elementName =
+			issue.nodeData?.nodeType === "TEXT" ? issue.nodeData?.characters : issue.nodeData?.name;
+
+		const description =
+			issue.type === "CONTRAST"
+				? getContrastIssueDescription(issue.nodeData.contrastScore?.compliance, targetLevel)
+				: issue.description;
+
+		return {
+			elementType: issue.nodeData?.nodeType || "N/A",
+			elementName: elementName || "N/A",
+			description,
+			severity: issue.severity,
+			type: (issue.type && ISSUE_TYPE_LABELS[issue.type]) || issue.type,
+			wcagCitation: issue.type ? getWcagCitation(issue.type, targetLevel).citation : "N/A",
+			wcagCitationUrl: issue.type ? getWcagCitation(issue.type, targetLevel).url : "N/A",
+			wcagContrastScore: issue.nodeData?.contrastScore?.compliance || "N/A",
+			contrastRatio: issue.nodeData?.contrastScore?.ratio.toFixed(2) || "N/A",
+			apcaLc: issue.nodeData?.apcaScore
+				? Math.round(Math.abs(issue.nodeData.apcaScore.lc))
+				: "N/A",
+			apcaMeetsMinimum: issue.nodeData?.apcaScore
+				? issue.nodeData.apcaScore.meetsMinimum
+					? "Pass"
+					: "Fail"
+				: "N/A",
+			wcagApcaDisagree: issue.nodeData?.apcaScore
+				? contrastMethodsDisagree(
+						issue.nodeData.contrastScore?.compliance,
+						targetLevel,
+						issue.nodeData.apcaScore.meetsMinimum,
+					)
+					? "Yes"
+					: "No"
+				: "N/A",
+			fontSize: issue.nodeData?.fontSize || "N/A",
+		};
+	});
+}
+
+export function generateCSVReport(formattedIssues: FormattedIssue[]): void {
+	const csvHeader =
+		"Element Type,Element Name,Issue Type,WCAG SC Citation,WCAG SC URL,Description,Severity,WCAG Contrast Score, WCAG Contrast Ratio,APCA Lc,APCA Meets Minimum,WCAG/APCA Disagree,Font Size";
+
+	const csvRows = formattedIssues.map((issue) => {
+		return [
+			`"${issue.elementType || "N/A"}"`, // Element Type
+			`"${issue.elementName}"`, // Element Name
+			`"${issue.type || "N/A"}"`, // Issue Type
+			`"${issue.wcagCitation || "N/A"}"`, // WCAG SC Citation
+			`"${issue.wcagCitationUrl || "N/A"}"`, // WCAG SC URL
+			`"${issue.description || ""}"`, // Description
+			`"${issue.severity || "N/A"}"`, // Severity
+			`"${issue.wcagContrastScore || "N/A"}"`, // WCAG Score
+			`"${issue.contrastRatio || "N/A"}"`, // Contrast ratio
+			`"${issue.apcaLc}"`, // APCA Lc
+			`"${issue.apcaMeetsMinimum}"`, // APCA Meets Minimum
+			`"${issue.wcagApcaDisagree}"`, // WCAG/APCA Disagree
+			`"${issue.fontSize || "N/A"}"`, // Font Size
+		].join(",");
+	});
+
+	const csvContent = [csvHeader, ...csvRows].join("\n");
+	const csvBlob = new Blob([csvContent], { type: "text/csv" });
+
+	saveAs(csvBlob, "accessibility-issues-report.csv");
+}
+
+export function generateJSONReport(formattedIssues: FormattedIssue[]): void {
+	const jsonBlob = new Blob([JSON.stringify(formattedIssues, null, 2)], {
+		type: "application/json",
+	});
+	saveAs(jsonBlob, "accessibility-issues-report.json");
+}
+
+export function generateMarkdownReport(
+	formattedIssues: FormattedIssue[],
+	isFileScan: boolean,
+): void {
+	const scope = isFileScan ? "across this file" : "on this page";
+	const generatedOn = new Date().toLocaleDateString("en-GB");
+	const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
+
+	const severityOrder: Severity[] = ["critical", "major", "minor"];
+	const bySeverity = severityOrder.map((severity) => ({
+		severity,
+		issues: formattedIssues.filter((issue) => issue.severity === severity),
+	}));
+
+	const lines: string[] = [
+		"# Accessibility Issues Report",
+		"",
+		`Generated ${generatedOn} - ${formattedIssues.length} issue${formattedIssues.length === 1 ? "" : "s"} detected ${scope}.`,
+		"",
+		"## Summary",
+		"",
+		"| Severity | Count |",
+		"|---|---|",
+		...bySeverity.map(
+			({ severity, issues }) => `| ${capitalize(severity)} | ${issues.length} |`,
+		),
+		"",
+	];
+
+	bySeverity.forEach(({ severity, issues }) => {
+		if (issues.length === 0) return;
+
+		lines.push(`## ${capitalize(severity)}`, "");
+
+		issues.forEach((issue, index) => {
+			lines.push(`### ${index + 1}. ${issue.type} - ${issue.elementName}`, "");
+			lines.push(`- **Element type:** ${issue.elementType}`);
+
+			const citationText =
+				issue.wcagCitationUrl !== "N/A"
+					? `[${issue.wcagCitation}](${issue.wcagCitationUrl})`
+					: issue.wcagCitation;
+			lines.push(`- **WCAG citation:** ${citationText}`);
+
+			lines.push(`- **Description:** ${issue.description}`);
+
+			if (issue.wcagContrastScore !== "N/A") {
+				lines.push(
+					`- **WCAG contrast score:** ${issue.wcagContrastScore} (ratio ${issue.contrastRatio}:1)`,
+				);
+			}
+			if (issue.apcaLc !== "N/A") {
+				lines.push(
+					`- **APCA:** Lc ${issue.apcaLc} (${issue.apcaMeetsMinimum}) - WCAG/APCA disagree: ${issue.wcagApcaDisagree}`,
+				);
+			}
+			if (issue.fontSize !== "N/A") {
+				lines.push(`- **Font size:** ${issue.fontSize}px`);
+			}
+
+			lines.push("");
+		});
+	});
+
+	const markdownBlob = new Blob([lines.join("\n")], { type: "text/markdown" });
+	saveAs(markdownBlob, "accessibility-issues-report.md");
+}

--- a/src/lib/wcagCitations/index.test.ts
+++ b/src/lib/wcagCitations/index.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import getWcagCitation from "./index";
+
+describe("getWcagCitation", () => {
+	it("cites SC 1.4.3 Contrast (Minimum) for CONTRAST at AA", () => {
+		const result = getWcagCitation("CONTRAST", "AA");
+
+		expect(result.exact).toBe(true);
+		expect(result.citation).toContain("1.4.3");
+		expect(result.url).toBe(
+			"https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html",
+		);
+	});
+
+	it("cites SC 1.4.6 Contrast (Enhanced) for CONTRAST at AAA", () => {
+		const result = getWcagCitation("CONTRAST", "AAA");
+
+		expect(result.exact).toBe(true);
+		expect(result.citation).toContain("1.4.6");
+		expect(result.url).toBe(
+			"https://www.w3.org/WAI/WCAG22/Understanding/contrast-enhanced.html",
+		);
+	});
+
+	it("cites SC 2.5.8 Target Size (Minimum) for TOUCH_TARGET_SIZE at AA", () => {
+		const result = getWcagCitation("TOUCH_TARGET_SIZE", "AA");
+
+		expect(result.exact).toBe(true);
+		expect(result.citation).toContain("2.5.8");
+		expect(result.url).toBe(
+			"https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html",
+		);
+	});
+
+	it("cites SC 2.5.5 Target Size (Enhanced) for TOUCH_TARGET_SIZE at AAA", () => {
+		const result = getWcagCitation("TOUCH_TARGET_SIZE", "AAA");
+
+		expect(result.exact).toBe(true);
+		expect(result.citation).toContain("2.5.5");
+		expect(result.url).toBe(
+			"https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html",
+		);
+	});
+
+	it("cites the same SC number and URL as TOUCH_TARGET_SIZE for TOUCH_TARGET_SPACING at AA", () => {
+		const spacing = getWcagCitation("TOUCH_TARGET_SPACING", "AA");
+		const size = getWcagCitation("TOUCH_TARGET_SIZE", "AA");
+
+		expect(spacing.citation).toContain("2.5.8");
+		expect(spacing.citation).toContain("spacing exception");
+		expect(spacing.url).toBe(size.url);
+	});
+
+	it("cites the same SC number and URL as TOUCH_TARGET_SIZE for TOUCH_TARGET_SPACING at AAA", () => {
+		const spacing = getWcagCitation("TOUCH_TARGET_SPACING", "AAA");
+		const size = getWcagCitation("TOUCH_TARGET_SIZE", "AAA");
+
+		expect(spacing.citation).toContain("2.5.5");
+		expect(spacing.citation).toContain("spacing exception");
+		expect(spacing.url).toBe(size.url);
+	});
+
+	it("returns an explicit 'no exact SC' citation for TYPOGRAPHY, not a fabricated number", () => {
+		const result = getWcagCitation("TYPOGRAPHY", "AA");
+
+		expect(result.exact).toBe(false);
+		expect(result.citation).toContain("No exact WCAG SC");
+		expect(result.citation).toContain("1.4.4");
+	});
+
+	it("still returns a working, real URL for TYPOGRAPHY despite having no exact SC", () => {
+		const result = getWcagCitation("TYPOGRAPHY", "AA");
+
+		expect(result.url).toBe("https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html");
+	});
+
+	it("returns the same typography citation regardless of target level", () => {
+		expect(getWcagCitation("TYPOGRAPHY", "AA")).toEqual(getWcagCitation("TYPOGRAPHY", "AAA"));
+	});
+
+	it("returns a real w3.org URL for every issue type and level, never a placeholder", () => {
+		const issueTypes: Array<Parameters<typeof getWcagCitation>[0]> = [
+			"CONTRAST",
+			"TYPOGRAPHY",
+			"TOUCH_TARGET_SIZE",
+			"TOUCH_TARGET_SPACING",
+		];
+		const levels: Array<Parameters<typeof getWcagCitation>[1]> = ["AA", "AAA"];
+
+		issueTypes.forEach((issueType) => {
+			levels.forEach((level) => {
+				expect(getWcagCitation(issueType, level).url).toMatch(/^https:\/\/www\.w3\.org\//);
+			});
+		});
+	});
+});

--- a/src/lib/wcagCitations/index.ts
+++ b/src/lib/wcagCitations/index.ts
@@ -1,0 +1,116 @@
+import { IssueType, TargetLevel } from "../types";
+
+export type WcagCitation = {
+	/**
+	 * False only for TYPOGRAPHY - no ratified numbered WCAG SC exists for a
+	 * minimum font size; WCAG addresses text sizing via SC 1.4.4 Resize Text
+	 * instead (zoom/reflow to 200%, not a hard minimum size) - related but not
+	 * an exact match. Kept as an explicit boolean, not inferred from string
+	 * content, so the inexact case can be asserted distinctly rather than
+	 * silently reading like every other row.
+	 */
+	exact: boolean;
+	/**
+	 * Ready-to-print citation string - the only field CSV/JSON/Markdown need
+	 * directly. Exact example: "WCAG 1.4.3 Contrast (Minimum) (AA)". Inexact
+	 * example: "No exact WCAG SC (readability best practice) - related: WCAG
+	 * 1.4.4 Resize Text" - always spells out "No exact"/"related" so it can
+	 * never be mistaken for a real numbered citation at a glance.
+	 */
+	citation: string;
+	/**
+	 * Official W3C WAI "Understanding" page for the cited SC - lets a reader
+	 * verify the citation against the primary source instead of taking the
+	 * plugin's word for it. Always present, even for the inexact TYPOGRAPHY
+	 * case (points to 1.4.4's own page, consistent with the citation string
+	 * already disclosing it's "related", not exact).
+	 */
+	url: string;
+};
+
+// Every URL below was fetched and confirmed live (200, correct page title)
+// while scoping this feature (10/08/2026) - W3C WAI's own "Understanding SC
+// X.X.X" pages, canonical form includes the .html suffix.
+const CONTRAST_MINIMUM_URL = "https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html";
+const CONTRAST_ENHANCED_URL = "https://www.w3.org/WAI/WCAG22/Understanding/contrast-enhanced.html";
+const TARGET_SIZE_MINIMUM_URL =
+	"https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html";
+const TARGET_SIZE_ENHANCED_URL =
+	"https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html";
+const RESIZE_TEXT_URL = "https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html";
+
+const LEVEL_AWARE_CITATIONS: Record<
+	Extract<IssueType, "CONTRAST" | "TOUCH_TARGET_SIZE" | "TOUCH_TARGET_SPACING">,
+	Record<TargetLevel, WcagCitation>
+> = {
+	CONTRAST: {
+		AA: {
+			exact: true,
+			citation: "WCAG 1.4.3 Contrast (Minimum) (AA)",
+			url: CONTRAST_MINIMUM_URL,
+		},
+		AAA: {
+			exact: true,
+			citation: "WCAG 1.4.6 Contrast (Enhanced) (AAA)",
+			url: CONTRAST_ENHANCED_URL,
+		},
+	},
+	TOUCH_TARGET_SIZE: {
+		AA: {
+			exact: true,
+			citation: "WCAG 2.5.8 Target Size (Minimum) (AA)",
+			url: TARGET_SIZE_MINIMUM_URL,
+		},
+		AAA: {
+			exact: true,
+			citation: "WCAG 2.5.5 Target Size (Enhanced) (AAA)",
+			url: TARGET_SIZE_ENHANCED_URL,
+		},
+	},
+	TOUCH_TARGET_SPACING: {
+		// Not a separate numbered SC - WCAG 2.2's spacing exception lives
+		// inside 2.5.8/2.5.5 itself (a target below the minimum size still
+		// conforms with enough offset to its neighbours), so this cites (and
+		// links to) the same SC as TOUCH_TARGET_SIZE, with a clarifying suffix
+		// so a reader isn't confused why a "Spacing" issue cites a "Target
+		// Size" criterion.
+		AA: {
+			exact: true,
+			citation: "WCAG 2.5.8 Target Size (Minimum) (AA) - spacing exception",
+			url: TARGET_SIZE_MINIMUM_URL,
+		},
+		AAA: {
+			exact: true,
+			citation: "WCAG 2.5.5 Target Size (Enhanced) (AAA) - spacing exception",
+			url: TARGET_SIZE_ENHANCED_URL,
+		},
+	},
+};
+
+// WCAG defines no numbered SC for a hard minimum font size; 1.4.4 Resize Text
+// is the closest related one but governs zoom/reflow, not "this text is too
+// small." Level-independent (unlike the table above) since neither AA nor AAA
+// has an exact match. url still points to 1.4.4's real page - the citation
+// string's own "related:" wording already sets the right expectation, so a
+// working link here is honest, not misleading.
+const TYPOGRAPHY_CITATION: WcagCitation = {
+	exact: false,
+	citation: "No exact WCAG SC (readability best practice) - related: WCAG 1.4.4 Resize Text",
+	url: RESIZE_TEXT_URL,
+};
+
+/**
+ * The WCAG success-criterion citation for the given issue type at the given
+ * target level, including a link to the official W3C "Understanding" page so
+ * a reader can verify it against the primary source rather than take the
+ * plugin's word for it. TOUCH_TARGET_SPACING deliberately resolves to the
+ * same citation as TOUCH_TARGET_SIZE (see the table above); TYPOGRAPHY has no
+ * exact numbered SC and always returns the same level-independent citation.
+ */
+export default function getWcagCitation(
+	issueType: IssueType,
+	targetLevel: TargetLevel,
+): WcagCitation {
+	if (issueType === "TYPOGRAPHY") return TYPOGRAPHY_CITATION;
+	return LEVEL_AWARE_CITATIONS[issueType][targetLevel];
+}

--- a/src/lib/wcagCitations/index.ts
+++ b/src/lib/wcagCitations/index.ts
@@ -10,21 +10,7 @@ export type WcagCitation = {
 	 * silently reading like every other row.
 	 */
 	exact: boolean;
-	/**
-	 * Ready-to-print citation string - the only field CSV/JSON/Markdown need
-	 * directly. Exact example: "WCAG 1.4.3 Contrast (Minimum) (AA)". Inexact
-	 * example: "No exact WCAG SC (readability best practice) - related: WCAG
-	 * 1.4.4 Resize Text" - always spells out "No exact"/"related" so it can
-	 * never be mistaken for a real numbered citation at a glance.
-	 */
 	citation: string;
-	/**
-	 * Official W3C WAI "Understanding" page for the cited SC - lets a reader
-	 * verify the citation against the primary source instead of taking the
-	 * plugin's word for it. Always present, even for the inexact TYPOGRAPHY
-	 * case (points to 1.4.4's own page, consistent with the citation string
-	 * already disclosing it's "related", not exact).
-	 */
 	url: string;
 };
 
@@ -68,12 +54,6 @@ const LEVEL_AWARE_CITATIONS: Record<
 		},
 	},
 	TOUCH_TARGET_SPACING: {
-		// Not a separate numbered SC - WCAG 2.2's spacing exception lives
-		// inside 2.5.8/2.5.5 itself (a target below the minimum size still
-		// conforms with enough offset to its neighbours), so this cites (and
-		// links to) the same SC as TOUCH_TARGET_SIZE, with a clarifying suffix
-		// so a reader isn't confused why a "Spacing" issue cites a "Target
-		// Size" criterion.
 		AA: {
 			exact: true,
 			citation: "WCAG 2.5.8 Target Size (Minimum) (AA) - spacing exception",
@@ -87,12 +67,6 @@ const LEVEL_AWARE_CITATIONS: Record<
 	},
 };
 
-// WCAG defines no numbered SC for a hard minimum font size; 1.4.4 Resize Text
-// is the closest related one but governs zoom/reflow, not "this text is too
-// small." Level-independent (unlike the table above) since neither AA nor AAA
-// has an exact match. url still points to 1.4.4's real page - the citation
-// string's own "related:" wording already sets the right expectation, so a
-// working link here is honest, not misleading.
 const TYPOGRAPHY_CITATION: WcagCitation = {
 	exact: false,
 	citation: "No exact WCAG SC (readability best practice) - related: WCAG 1.4.4 Resize Text",


### PR DESCRIPTION
## Summary

"Exportable structured report (Markdown/JSON/CSV) with WCAG success-criterion citations - a real dev-handoff artifact free." CSV/JSON export already existed; Markdown did not.

- **New `src/lib/wcagCitations` module** - resolves each issue type (+ target level, for CONTRAST/TOUCH_TARGET_SIZE) to its exact WCAG SC citation and a link to the official W3C "Understanding" page. Every URL was fetched and confirmed live before shipping, not guessed from the otherwise-predictable slug pattern.
  - `TOUCH_TARGET_SPACING` deliberately cites the **same** SC as `TOUCH_TARGET_SIZE` - confirmed via WCAG 2.2's own spec text that spacing isn't a separate numbered criterion, it's the spacing-exception clause inside 2.5.8/2.5.5 itself.
  - `TYPOGRAPHY` has **no exact numbered SC** - WCAG deliberately sets no hard minimum font size. Rather than fabricate a precise-sounding citation, it returns an explicit "No exact WCAG SC (readability best practice) - related: WCAG 1.4.4 Resize Text" with a working link to that related page. Honesty over false precision, since this is a compliance tool.
  - No citation is added for APCA-scored data (`apcaLc`/`apcaMeetsMinimum`/`wcagApcaDisagree`) - APCA has no ratified WCAG SC number, still under evaluation for WCAG 3.
- **CSV/JSON exports** gain two new columns: `WCAG SC Citation`, `WCAG SC URL`.
- **New Markdown export** ("Download Markdown", third button alongside CSV/JSON) - reuses `formatIssuesForReport` as its sole data source, no duplicated formatting logic. Reads as a genuine handoff document rather than a table dump: title/summary, issues grouped by **severity** (critical first, matching dev-handoff triage order) rather than issue type, WCAG citation rendered as a real clickable Markdown link, and type-specific fields (contrast score, APCA, font size) included only when actually present for that issue.
- `CHANGELOG.md` v1.4.0 entry + `package.json` version bump (1.3.0 -> 1.4.0), roadmap checkbox checked off.

## Test plan
- [x] `npx tsc -b`
- [x] `npm run lint`
- [x] `npm run test` - 450/450 (new: `wcagCitations` unit tests covering every issue-type/level combination + the typography/spacing edge cases; `IssuesOverviewList` extensions for the new CSV/JSON columns and the full Markdown export - structure, severity grouping, clickable-link rendering, N/A-field omission)
- [x] `npm run build`
- [ ] Manual visual check still needed: confirm the three export buttons ("Download CSV" / "Download JSON" / "Download Markdown") don't wrap awkwardly in the report tab at the plugin's narrow panel width, in Figma dev mode or `npm run preview`.