### PR TITLE
feat(a11y): pair the WCAG citation with Recommendations in the UI

### DIFF
--- a/src/components/organisms/ContrastFixSuggester/index.tsx
+++ b/src/components/organisms/ContrastFixSuggester/index.tsx
@@ -62,7 +62,7 @@ export default function ContrastFixSuggester({
 										: "Lighten"}{" "}
 									text
 								</span>
-								<span className="inline-flex items-center gap-x-1 font-mono font-medium text-green-500">
+								<span className="inline-flex items-center gap-x-1 font-mono font-semibold text-green-500">
 									<Check aria-hidden="true" className="size-4" />
 									{foregroundSuggestion.ratio.toFixed(2)}:1
 								</span>
@@ -110,7 +110,7 @@ export default function ContrastFixSuggester({
 										: "Lighten"}{" "}
 									background
 								</span>
-								<span className="inline-flex items-center gap-x-1 font-mono font-medium text-green-500">
+								<span className="inline-flex items-center gap-x-1 font-mono font-semibold text-green-500">
 									<Check aria-hidden="true" className="size-4" />
 									{backgroundSuggestion.ratio.toFixed(2)}:1
 								</span>

--- a/src/components/organisms/ContrastFixSuggester/index.tsx
+++ b/src/components/organisms/ContrastFixSuggester/index.tsx
@@ -62,7 +62,7 @@ export default function ContrastFixSuggester({
 										: "Lighten"}{" "}
 									text
 								</span>
-								<span className="inline-flex items-center gap-x-1 font-mono text-green-500">
+								<span className="inline-flex items-center gap-x-1 font-mono font-medium text-green-500">
 									<Check aria-hidden="true" className="size-4" />
 									{foregroundSuggestion.ratio.toFixed(2)}:1
 								</span>
@@ -110,7 +110,7 @@ export default function ContrastFixSuggester({
 										: "Lighten"}{" "}
 									background
 								</span>
-								<span className="inline-flex items-center gap-x-1 font-mono text-green-500">
+								<span className="inline-flex items-center gap-x-1 font-mono font-medium text-green-500">
 									<Check aria-hidden="true" className="size-4" />
 									{backgroundSuggestion.ratio.toFixed(2)}:1
 								</span>

--- a/src/components/organisms/IssuesOverviewList/index.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.tsx
@@ -424,7 +424,7 @@ export default function IssuesOverviewList() {
 								</div>
 							)}
 
-							<div className="space-x-3">
+							<div className="flex flex-wrap gap-3">
 								<Button
 									title="Download CSV Report"
 									variant="default"

--- a/src/components/organisms/IssuesWrapper/index.test.tsx
+++ b/src/components/organisms/IssuesWrapper/index.test.tsx
@@ -274,7 +274,9 @@ describe("IssuesWrapper", () => {
 		const { rerender } = render(<IssuesWrapper>child</IssuesWrapper>);
 
 		expect(
-			screen.getByRole("link", { name: "WCAG 1.4.3 Contrast (Minimum) (AA)" }),
+			screen.getByRole("link", {
+				name: /WCAG 1\.4\.3 Contrast \(Minimum\) \(AA\).*opens in a new tab/,
+			}),
 		).toHaveAttribute(
 			"href",
 			"https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html",
@@ -284,7 +286,9 @@ describe("IssuesWrapper", () => {
 		rerender(<IssuesWrapper>child</IssuesWrapper>);
 
 		expect(
-			screen.getByRole("link", { name: "WCAG 1.4.6 Contrast (Enhanced) (AAA)" }),
+			screen.getByRole("link", {
+				name: /WCAG 1\.4\.6 Contrast \(Enhanced\) \(AAA\).*opens in a new tab/,
+			}),
 		).toHaveAttribute(
 			"href",
 			"https://www.w3.org/WAI/WCAG22/Understanding/contrast-enhanced.html",

--- a/src/components/organisms/IssuesWrapper/index.test.tsx
+++ b/src/components/organisms/IssuesWrapper/index.test.tsx
@@ -265,6 +265,32 @@ describe("IssuesWrapper", () => {
 		expect(screen.getByText("Recommendations")).toBeVisible();
 	});
 
+	it("passes a WCAG citation matching the current target level down to Recommendations", () => {
+		useIssuesStore.setState({
+			selectedType: "CONTRAST",
+			detectedIssues: [contrastFailIssue],
+			targetLevel: "AA",
+		});
+		const { rerender } = render(<IssuesWrapper>child</IssuesWrapper>);
+
+		expect(
+			screen.getByRole("link", { name: "WCAG 1.4.3 Contrast (Minimum) (AA)" }),
+		).toHaveAttribute(
+			"href",
+			"https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html",
+		);
+
+		useIssuesStore.setState({ targetLevel: "AAA" });
+		rerender(<IssuesWrapper>child</IssuesWrapper>);
+
+		expect(
+			screen.getByRole("link", { name: "WCAG 1.4.6 Contrast (Enhanced) (AAA)" }),
+		).toHaveAttribute(
+			"href",
+			"https://www.w3.org/WAI/WCAG22/Understanding/contrast-enhanced.html",
+		);
+	});
+
 	it("describes a genuine AA contrast failure as below WCAG AA standard", () => {
 		useIssuesStore.setState({
 			selectedType: "CONTRAST",

--- a/src/components/organisms/IssuesWrapper/index.tsx
+++ b/src/components/organisms/IssuesWrapper/index.tsx
@@ -12,6 +12,7 @@ import ISSUES_DATA_SCHEMA from "@/lib/issuesData";
 import { IssueType, DetectedIssue } from "@/lib/types";
 import useIssuesStore from "@/lib/useIssuesStore";
 import { cn, getContrastIssueDescription, getRouteForIssueType, isActiveIssue } from "@/lib/utils";
+import getWcagCitation from "@/lib/wcagCitations";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -189,6 +190,7 @@ export default function IssuesWrapper({ children }: { children: React.ReactNode 
 		targetLevel,
 		activeIssue?.nodeData?.requiredSizePx,
 	);
+	const citation = selectedType ? getWcagCitation(selectedType, targetLevel) : null;
 
 	const renderWrapper = (issue: typeof singleIssue | null) => {
 		if (!issue) {
@@ -227,7 +229,7 @@ export default function IssuesWrapper({ children }: { children: React.ReactNode 
 
 				{children}
 
-				<Recommendations recommendations={suggestions || []} />
+				<Recommendations recommendations={suggestions || []} citation={citation} />
 			</>
 		);
 	};

--- a/src/components/organisms/Recommendations/index.test.tsx
+++ b/src/components/organisms/Recommendations/index.test.tsx
@@ -51,6 +51,11 @@ describe("Recommendations", () => {
 			citation: "WCAG 1.4.3 Contrast (Minimum) (AA)",
 			url: "https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html",
 		};
+		// The rendered link appends a visually-hidden "(opens in a new tab)"
+		// suffix, which is part of its computed accessible name - matched via
+		// regex since accessible-name computation collapses the whitespace
+		// between the citation text and the sr-only suffix.
+		const linkAccessibleName = /WCAG 1\.4\.3 Contrast \(Minimum\) \(AA\).*opens in a new tab/;
 
 		it("does not render a citation link when none is given", () => {
 			render(<Recommendations recommendations={["Improve contrast."]} />);
@@ -66,7 +71,7 @@ describe("Recommendations", () => {
 				/>,
 			);
 
-			const link = screen.getByRole("link", { name: "WCAG 1.4.3 Contrast (Minimum) (AA)" });
+			const link = screen.getByRole("link", { name: linkAccessibleName });
 			expect(link).toBeVisible();
 			expect(screen.queryByRole("list")).toBeNull();
 		});
@@ -74,13 +79,20 @@ describe("Recommendations", () => {
 		it("points the citation link at the official source with a safe target", () => {
 			render(<Recommendations recommendations={["Improve contrast."]} citation={citation} />);
 
-			const link = screen.getByRole("link", { name: "WCAG 1.4.3 Contrast (Minimum) (AA)" });
+			const link = screen.getByRole("link", { name: linkAccessibleName });
 			expect(link).toHaveAttribute(
 				"href",
 				"https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html",
 			);
 			expect(link).toHaveAttribute("target", "_blank");
 			expect(link).toHaveAttribute("rel", "noopener noreferrer");
+		});
+
+		it("tells screen-reader users the link opens in a new tab", () => {
+			render(<Recommendations recommendations={["Improve contrast."]} citation={citation} />);
+
+			const link = screen.getByRole("link", { name: linkAccessibleName });
+			expect(link).toHaveTextContent("(opens in a new tab)");
 		});
 
 		it("clicking the citation link does not also toggle the recommendations list open", async () => {
@@ -92,9 +104,24 @@ describe("Recommendations", () => {
 				/>,
 			);
 
-			await user.click(
-				screen.getByRole("link", { name: "WCAG 1.4.3 Contrast (Minimum) (AA)" }),
+			await user.click(screen.getByRole("link", { name: linkAccessibleName }));
+
+			expect(screen.queryByRole("list")).toBeNull();
+		});
+
+		it("activating the citation link via the keyboard does not also toggle the recommendations list open", async () => {
+			const user = userEvent.setup();
+			render(
+				<Recommendations
+					recommendations={["Improve contrast.", "Use a larger font size."]}
+					citation={citation}
+				/>,
 			);
+
+			await user.tab();
+			expect(screen.getByRole("link", { name: linkAccessibleName })).toHaveFocus();
+
+			await user.keyboard("{Enter}");
 
 			expect(screen.queryByRole("list")).toBeNull();
 		});

--- a/src/components/organisms/Recommendations/index.test.tsx
+++ b/src/components/organisms/Recommendations/index.test.tsx
@@ -44,4 +44,59 @@ describe("Recommendations", () => {
 
 		expect(screen.getByRole("list")).toBeVisible();
 	});
+
+	describe("citation", () => {
+		const citation = {
+			exact: true,
+			citation: "WCAG 1.4.3 Contrast (Minimum) (AA)",
+			url: "https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html",
+		};
+
+		it("does not render a citation link when none is given", () => {
+			render(<Recommendations recommendations={["Improve contrast."]} />);
+
+			expect(screen.queryByRole("link")).toBeNull();
+		});
+
+		it("renders the citation as a link even while the recommendations list is collapsed", () => {
+			render(
+				<Recommendations
+					recommendations={["Improve contrast.", "Use a larger font size."]}
+					citation={citation}
+				/>,
+			);
+
+			const link = screen.getByRole("link", { name: "WCAG 1.4.3 Contrast (Minimum) (AA)" });
+			expect(link).toBeVisible();
+			expect(screen.queryByRole("list")).toBeNull();
+		});
+
+		it("points the citation link at the official source with a safe target", () => {
+			render(<Recommendations recommendations={["Improve contrast."]} citation={citation} />);
+
+			const link = screen.getByRole("link", { name: "WCAG 1.4.3 Contrast (Minimum) (AA)" });
+			expect(link).toHaveAttribute(
+				"href",
+				"https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html",
+			);
+			expect(link).toHaveAttribute("target", "_blank");
+			expect(link).toHaveAttribute("rel", "noopener noreferrer");
+		});
+
+		it("clicking the citation link does not also toggle the recommendations list open", async () => {
+			const user = userEvent.setup();
+			render(
+				<Recommendations
+					recommendations={["Improve contrast.", "Use a larger font size."]}
+					citation={citation}
+				/>,
+			);
+
+			await user.click(
+				screen.getByRole("link", { name: "WCAG 1.4.3 Contrast (Minimum) (AA)" }),
+			);
+
+			expect(screen.queryByRole("list")).toBeNull();
+		});
+	});
 });

--- a/src/components/organisms/Recommendations/index.tsx
+++ b/src/components/organisms/Recommendations/index.tsx
@@ -1,7 +1,8 @@
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
 import { WcagCitation } from "@/lib/wcagCitations";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, ExternalLink } from "lucide-react";
 import { useState } from "react";
 
 export type RecommendationsProps = {
@@ -22,7 +23,12 @@ export default function Recommendations({ recommendations, citation }: Recommend
 	return (
 		<Collapsible open={open} onOpenChange={setOpen} className="w-full">
 			<CollapsibleTrigger asChild>
-				<div className="flex cursor-pointer items-center justify-between space-x-4 rounded-md border border-rose-50/20 px-4 py-2">
+				<div
+					className={cn(
+						"flex cursor-pointer items-center justify-between gap-x-2 rounded-md border border-rose-50/20 px-3 py-2",
+						{ "rounded-b-none border-b-0!": open },
+					)}
+				>
 					<div>
 						<h4 className="font-open-sans text-sm font-semibold">Recommendations</h4>
 						{citation && (
@@ -31,10 +37,12 @@ export default function Recommendations({ recommendations, citation }: Recommend
 								target="_blank"
 								rel="noopener noreferrer"
 								onClick={(event) => event.stopPropagation()}
-								className="mt-0.5 inline-block rounded-sm text-xs text-accent underline decoration-accent/40 underline-offset-2 hover:decoration-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-dark-shade focus-visible:outline-hidden"
+								className="mt-0.5 inline-flex items-center gap-1 rounded-sm text-xs text-accent underline decoration-accent/40 underline-offset-2 hover:decoration-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-dark-shade focus-visible:outline-hidden"
 							>
 								{citation.citation}
 								<span className="sr-only"> (opens in a new tab)</span>
+
+								<ExternalLink aria-hidden="true" className="size-4" />
 							</a>
 						)}
 					</div>
@@ -48,7 +56,11 @@ export default function Recommendations({ recommendations, citation }: Recommend
 				</div>
 			</CollapsibleTrigger>
 
-			<CollapsibleContent className="my-2">
+			<CollapsibleContent
+				className={cn("rounded-md border border-rose-50/20", {
+					"rounded-t-none border-t-0!": open,
+				})}
+			>
 				<div className="p-2.5 text-sm">
 					{recommendations.length === 1 ? (
 						<p>{recommendations[0]}</p>

--- a/src/components/organisms/Recommendations/index.tsx
+++ b/src/components/organisms/Recommendations/index.tsx
@@ -31,9 +31,10 @@ export default function Recommendations({ recommendations, citation }: Recommend
 								target="_blank"
 								rel="noopener noreferrer"
 								onClick={(event) => event.stopPropagation()}
-								className="mt-0.5 inline-block text-xs text-accent underline decoration-accent/40 underline-offset-2 hover:decoration-accent"
+								className="mt-0.5 inline-block rounded-sm text-xs text-accent underline decoration-accent/40 underline-offset-2 hover:decoration-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-dark-shade focus-visible:outline-hidden"
 							>
 								{citation.citation}
+								<span className="sr-only"> (opens in a new tab)</span>
 							</a>
 						)}
 					</div>

--- a/src/components/organisms/Recommendations/index.tsx
+++ b/src/components/organisms/Recommendations/index.tsx
@@ -1,9 +1,21 @@
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { WcagCitation } from "@/lib/wcagCitations";
 import { ChevronDown } from "lucide-react";
 import { useState } from "react";
 
-export default function Recommendations({ recommendations }: { recommendations: string[] }) {
+export type RecommendationsProps = {
+	recommendations: string[];
+	/**
+	 * Shown as a link under the "Recommendations" heading, in the trigger row
+	 * itself rather than inside CollapsibleContent - so it stays visible even
+	 * while collapsed, unlike the recommendation bullets it sits above. Optional
+	 * since not every caller resolves a citation (e.g. no selectedType yet).
+	 */
+	citation?: WcagCitation | null;
+};
+
+export default function Recommendations({ recommendations, citation }: RecommendationsProps) {
 	const [open, setOpen] = useState(false);
 	if (!recommendations || recommendations.length === 0) return null;
 
@@ -11,7 +23,20 @@ export default function Recommendations({ recommendations }: { recommendations: 
 		<Collapsible open={open} onOpenChange={setOpen} className="w-full">
 			<CollapsibleTrigger asChild>
 				<div className="flex cursor-pointer items-center justify-between space-x-4 rounded-md border border-rose-50/20 px-4 py-2">
-					<h4 className="font-open-sans text-sm font-semibold">Recommendations</h4>
+					<div>
+						<h4 className="font-open-sans text-sm font-semibold">Recommendations</h4>
+						{citation && (
+							<a
+								href={citation.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={(event) => event.stopPropagation()}
+								className="mt-0.5 inline-block text-xs text-accent underline decoration-accent/40 underline-offset-2 hover:decoration-accent"
+							>
+								{citation.citation}
+							</a>
+						)}
+					</div>
 					<Button title="View recommendations" variant="nude" size="sm">
 						<ChevronDown
 							aria-hidden="true"


### PR DESCRIPTION
## Summary
- Surfaces the WCAG success-criterion citation (from `src/lib/wcagCitations`, introduced in #64) directly in the live UI, as a link paired with the `Recommendations` section, rather than only in exported reports.
- Chosen over a standalone detail row after reviewing both options side-by-side: the citation stays visible even while Recommendations is collapsed, without adding a new always-on detail row to every issue card.
- Follow-up accessibility pass (via the `web-accessibility` agent, per the new AGENTS.md rule) found no AA blockers, but flagged the citation link as the only interactive element in the codebase without an explicit `focus-visible` style, and recommended a screen-reader-only "opens in a new tab" notice since it's the plugin's first `target="_blank"` link. Both fixed here.

## What's included
- `Recommendations` gains an optional `citation` prop, rendered as a link in the collapsible's trigger row with `stopPropagation` so clicking it doesn't also toggle the recommendations list.
- `IssuesWrapper` resolves the citation via `getWcagCitation(selectedType, targetLevel)` and passes it through — confirmed via test that the link's `href` (not just its visible text) tracks the current AA/AAA target level.
- Fixed a pre-existing inline-prop-type violation in `Recommendations` while touching the file (now a named, exported `RecommendationsProps` type).

## Dependency
Stacked on #64 (`feat/wcag-citations-and-markdown-export`, still open) — this branch imports `getWcagCitation` from that PR's `src/lib/wcagCitations` module, so this PR targets that branch rather than `main` and should merge after it.

## Test plan
- [x] `npx tsc -b`, `npm run lint`, `npm run build` all clean
- [x] `npm run test -- --run` — 457/457 passing, including new coverage for: citation link visible while collapsed, correct `href`/`target`/`rel`, click doesn't toggle the list, keyboard (Enter) activation doesn't toggle the list, new-tab screen-reader notice, and href tracking the live AA/AAA toggle
- [ ] Manual check in Figma dev mode: focus ring renders correctly on the citation link, and the link actually opens in the user's browser from within Figma's plugin iframe (not verifiable via vitest)