### PR TITLE
fix(scan): show a spinner during file scans so progress doesn't look frozen

### DIFF
--- a/src/components/organisms/IssuesOverviewList/index.test.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.test.tsx
@@ -148,6 +148,21 @@ describe("IssuesOverviewList", () => {
 		).toBeVisible();
 		expect(screen.getByRole("tablist")).toBeVisible();
 		expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
+		expect(screen.getByTestId("file-scan-progress-spinner")).toBeVisible();
+	});
+
+	it("announces file-scan progress updates to screen readers via a polite status region", () => {
+		useIssuesStore.setState({
+			scanning: true,
+			isFileScan: true,
+			fileScanProgress: { pageIndex: 2, pageCount: 5, pageName: "About" },
+			detectedIssues: [typographyIssue],
+		});
+		render(<IssuesOverviewList />);
+
+		expect(screen.getByRole("status")).toHaveTextContent(
+			/Scanning page 2 of 5: About\. Results below update/,
+		);
 	});
 
 	it("cancels the file scan when the cancel button is clicked", async () => {
@@ -178,6 +193,8 @@ describe("IssuesOverviewList", () => {
 		expect(screen.getByText("Finishing up - page 3 of 5...")).toBeVisible();
 		expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
 		expect(screen.queryByText(/Scan cancelled/)).toBeNull();
+		expect(screen.getByTestId("file-scan-progress-spinner")).toBeVisible();
+		expect(screen.getByRole("status")).toHaveTextContent("Finishing up - page 3 of 5...");
 	});
 
 	it("shows a partial-results banner after a cancelled file scan's results arrive", () => {

--- a/src/components/organisms/IssuesOverviewList/index.tsx
+++ b/src/components/organisms/IssuesOverviewList/index.tsx
@@ -6,6 +6,7 @@ import ScanSettingsReadout from "@/components/organisms/ScanSettingsReadout";
 import ScreenHeader from "@/components/organisms/ScreenHeader";
 import TargetLevelToggle from "@/components/organisms/TargetLevelToggle";
 import { Button } from "@/components/ui/button";
+import LoadingSpinner from "@/components/ui/loadingSpinner";
 import Separator from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ISSUES_TYPES } from "@/lib/constants";
@@ -111,7 +112,17 @@ export default function IssuesOverviewList() {
 				<div className="flex size-full flex-col">
 					{scanning && isFileScan && fileScanProgress && (
 						<div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-rose-50/10 bg-dark-shade px-3 py-2 text-xs text-grey">
-							<span>
+							<span
+								className="flex items-center gap-2"
+								role="status"
+								aria-atomic="true"
+							>
+								{fileScanCancelled && (
+									<LoadingSpinner
+										className="size-4 shrink-0"
+										testId="file-scan-progress-spinner"
+									/>
+								)}
 								{fileScanCancelled
 									? `Finishing up - page ${fileScanProgress.pageIndex} of ${fileScanProgress.pageCount}...`
 									: `Scanning page ${fileScanProgress.pageIndex} of ${fileScanProgress.pageCount}: ${fileScanProgress.pageName}. Results below update as more pages finish.`}
@@ -120,9 +131,13 @@ export default function IssuesOverviewList() {
 								<Button
 									title="Cancel scan"
 									variant="ghost"
-									className="shrink-0 border border-rose-50/10"
+									className="shrink-0 gap-1.5 border border-rose-50/10"
 									onClick={cancelFileScan}
 								>
+									<LoadingSpinner
+										className="size-4 shrink-0"
+										testId="file-scan-progress-spinner"
+									/>
 									Cancel
 								</Button>
 							)}

--- a/src/components/ui/loadingSpinner/index.tsx
+++ b/src/components/ui/loadingSpinner/index.tsx
@@ -1,9 +1,15 @@
 import { cn } from "@/lib/utils";
 
-export default function LoadingSpinner({ className }: { className?: string }) {
+export type LoadingSpinnerProps = {
+	className?: string;
+	testId?: string;
+};
+
+export default function LoadingSpinner({ className, testId }: LoadingSpinnerProps) {
 	return (
 		<svg
 			aria-hidden="true"
+			data-testid={testId}
 			className={cn("animate-spin fill-accent text-white", className)}
 			viewBox="0 0 100 101"
 			fill="none"


### PR DESCRIPTION
## Summary
- Long multi-page file scans left the progress banner as static text with no motion, which read as frozen on large files.
- Moves the loading spinner into the "Cancel" button during active scanning - considered a few placements first (mocked up side by side), landed on this one since it ties the motion to the one control that actually does something about it.
- The "finishing up" state (after Cancel is clicked, before the last in-flight page lands) has no Cancel button to attach a spinner to, so it keeps the spinner in the status text instead - otherwise that state would lose its "still running" signal entirely, right when it matters most.
- Accessibility pass (per the AGENTS.md rule) caught a real gap beyond the visual fix: neither banner state announced its progress text to screen readers as it updated. Added `role="status" aria-atomic="true"` to close that, with test coverage for both states.
- `LoadingSpinner` gains an optional `testId` prop so it can be targeted directly in tests instead of a fragile CSS-class selector.

## Test plan
- [x] `npx tsc -b`, `npm run lint`, `npm run build` all clean
- [x] `npm run test -- --run` - 465/465 passing, including new coverage for the spinner's presence in both banner states and the live-region announcement
- [ ] Manual check in Figma dev mode: run a real multi-page file scan and confirm the spinner reads clearly as "still running," not as the Cancel button itself being disabled/loading