### PR TITLE
docs: confirm 1.4.0 published as Figma Version 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Two version numbers appear in this project and they are **not** the same thing:
 
 Versions 2-10's descriptions are transcribed as originally published on Figma - full commit-level detail for that period isn't available since this changelog was only introduced retroactively (06/08/2026).
 
-## [1.4.0] - Figma Version 15 (provisional - Figma's version number auto-increments on publish, confirm once actually published) - 11/08/2026
+## [1.4.0] - Figma Version 15 - 11/08/2026
 
 ### Added
 


### PR DESCRIPTION
## Summary
- Drops the "provisional" note on the 1.4.0 changelog entry - confirmed against the plugin's actual Version history on Figma Community that this published as Version 15 on 11/08/2026, matching the prediction.

## Test plan
- [x] Docs-only change, no code touched